### PR TITLE
Fuse LN+GEMM in LN+QKV Proj, remove incorrect extra LN before LNMLP block

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -737,9 +737,3 @@ rope_theta_for_vit: 10000
 vision_output_dim_for_vit: 4096
 pixel_shuffle_ratio_for_vit: 0.5
 projector_dropout_for_vit: 0.0
-# Transformer Engine
-te_modules: False
-te_norm: False
-te_mlp: False
-te_dense_general: False
-te_fp8: False

--- a/MaxText/configs/base_edited.yml
+++ b/MaxText/configs/base_edited.yml
@@ -250,7 +250,7 @@ qk_rope_head_dim: 64
 v_head_dim: 128
 
 # Combine matmuls for QKV and MLP
-fused_qkv: False
+fused_qkv: True
 fused_mlp: False
 
 record_internal_nn_metrics: 0

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -50,6 +50,8 @@ from MaxText.layers.linears import DenseGeneral
 from MaxText.layers.normalizations import RMSNorm
 from MaxText.layers.quantizations import AqtQuantization as Quant
 
+from transformer_engine.jax.flax.module import LayerNormDenseGeneral as TELayerNormDenseGeneral
+
 # pylint: disable=line-too-long, g-doc-args, g-doc-return-or-yield, bad-continuation, g-inconsistent-quotes
 # pytype: disable=attribute-error
 
@@ -1244,6 +1246,8 @@ class Attention(nn.Module):
   is_nope_layer: bool = False
   is_vision: bool = False
 
+  norm_inputs: bool = False  # Whether to apply normalization to inputs before attention.
+
   def setup(self):
     """init with attention_op and possibly paged_attention_op"""
     self.attention_op = AttentionOp(
@@ -1353,22 +1357,42 @@ class Attention(nn.Module):
     )(inputs_kv)
     return kv_proj
 
-  def qkv_projection(self, inputs: Array, proj_name: str):
+  def qkv_projection(self, inputs: Array, proj_name: str, norm_inputs: bool = False):
     """Fused QKV projection"""
 
-    qkv_proj = DenseGeneral(
-        features=(3, self.num_query_heads, self.head_dim),
+    if self.norm_inputs and self.config.te_dense_general and self.config.te_norm:
+      features = (3, self.num_query_heads, self.head_dim)
+      kernel_in_axis = np.arange(0)
+      kernel_out_axis = np.arange(0, 0 + len(features))
+      lnx_rms = TELayerNormDenseGeneral(
+        features=features,
         axis=-1,
-        kernel_init=self.kernel_init,
+        dtype=self.config.dtype,
+        name="pre_self_attention_layer_norm",
+        scale_axes=("norm",),
+        ln_bias_axes=("norm",),
+        kernel_init=partial(self.kernel_init, in_axis=kernel_in_axis, out_axis=kernel_out_axis),
         kernel_axes=("embed", "qkv", "heads", "kv"),
-        dtype=self.dtype,
-        weight_dtype=self.weight_dtype,
-        name=proj_name,
-        quant=self.quant,
-        matmul_precision=self.config.matmul_precision,
-        use_bias=self.use_bias_in_projections,
-        dot_kernel="te_dot" if self.config.te_dense_general else None
-    )(inputs)
+        dot_input_axes=("activation_batch", "activation_norm_length", "activation_embed"),
+        epsilon=self.config.normalization_layer_epsilon,
+        return_layernorm_output=False,
+      )
+      qkv_proj, _ = lnx_rms(inputs)
+
+    else:
+      qkv_proj = DenseGeneral(
+          features=(3, self.num_query_heads, self.head_dim),
+          axis=-1,
+          kernel_init=self.kernel_init,
+          kernel_axes=("embed", "qkv", "heads", "kv"),
+          dtype=self.dtype,
+          weight_dtype=self.weight_dtype,
+          name=proj_name,
+          quant=self.quant,
+          matmul_precision=self.config.matmul_precision,
+          use_bias=self.use_bias_in_projections,
+          dot_kernel="te_dot" if self.config.te_dense_general else None
+      )(inputs)
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
     return query, key, value
@@ -1521,9 +1545,11 @@ class Attention(nn.Module):
       inputs_q = nn.with_logical_constraint(inputs_q, self.decode_input_axis_names)
       inputs_kv = nn.with_logical_constraint(inputs_kv, self.decode_input_axis_names)
 
+    assert not self.norm_inputs or self.config.fused_qkv, "norm_inputs is only supported with fused_qkv=True"
+
     # apply projection.
     if self.config.fused_qkv:
-      query, key, value = self.qkv_projection(inputs_q, proj_name="qkv_proj")
+      query, key, value = self.qkv_projection(inputs_q, proj_name="qkv_proj", norm_inputs=self.norm_inputs)
     else:
       query = self.query_projection(inputs_q)
       key = self.kv_projection(inputs_kv, proj_name="key")

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -224,6 +224,7 @@ def get_mlp_block(cfg):
     lnmlp_expected_args["layernorm_type"] = "rmsnorm"
     lnmlp_expected_args["kernel_axes_1"] = ("embed", None, "mlp")
     lnmlp_expected_args["kernel_axes_2"] = ("mlp", "embed")
+    lnmlp_expected_args["return_layernorm_output"] = False
     te_lnmlp_initialized = LayerNormMLP(**lnmlp_expected_args)
 
 


### PR DESCRIPTION
# Description

* Used TE "fused" Flax layers to keep intermediate results in FP8 instead of dequantizing between layers and re-quantizing before GEMMs
* Enable fused QKV in config
* Remove incorrect extra LN in MLP block logic, previously was doing LN + LNMLP layer but is not just doing LNMLP layer
