### PR TITLE
Add num-decoder-layers option

### DIFF
--- a/end_to_end/te/normalize.py
+++ b/end_to_end/te/normalize.py
@@ -34,7 +34,7 @@ rows = []
 # iterate keys in first-seen order
 for key in key_order:
     rowset = data[key]
-    baseline = rowset.get("maxtext_fp8", {})
+    baseline = rowset.get("fp8", {})
     base_mean = baseline.get("mean", "NA")
     try:
         base_mean_val = float(base_mean)
@@ -49,7 +49,8 @@ for key in key_order:
         stddev = row["stddev"]
         if mean == "NA":
             normalized = "-"
-        elif testname == "maxtext_fp8":
+        elif testname == "fp8":
+            testname = "maxtext_fp8"
             normalized = "0.00%" if has_baseline else "-"
         elif has_baseline and mean != "NA":
             try:

--- a/end_to_end/te/run_single_node_model_parallel.sh
+++ b/end_to_end/te/run_single_node_model_parallel.sh
@@ -43,6 +43,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+[[ "$TRACE" == "true" ]] && OUTPUT_DIR_TAG="trace${OUTPUT_DIR_TAG:+_$OUTPUT_DIR_TAG}"
+
 # Now your variables are set as needed
 echo "MODEL=$MODEL"
 echo "OUTPUT_DIR_TAG=$OUTPUT_DIR_TAG"

--- a/end_to_end/te/run_single_node_model_parallel.sh
+++ b/end_to_end/te/run_single_node_model_parallel.sh
@@ -68,7 +68,7 @@ n_gpus=$(nvidia-smi -L | wc -l)
 half_gpus=$((n_gpus / 2))
 # List of experiments: <DP> <TP> <TPSP> <FSDP>
 experiments=(
-  # "1        1           1           1"        # Single GPU
+  "1        1           1           1"        # Single GPU
   "1        $n_gpus     1           1"        # Single DP, full TP
   "$n_gpus  1           1           1"        # Full DP, single TP
   "2        $half_gpus  1           1"        # DP=2, TP=half GPUs

--- a/end_to_end/te/test-maxtext-te.sh
+++ b/end_to_end/te/test-maxtext-te.sh
@@ -117,10 +117,6 @@ while [ : ]; do
         QUANTIZATION="$2"
         shift 2
         ;;
-    --enable-te)
-        ENABLE_TE=1
-        shift 1
-        ;;
     -s | --steps)
         STEPS="$2"
         shift 2


### PR DESCRIPTION
# Description

- Add an option to the run script to be able to run with a set number of decoder layers with or without tracing.
- Unify MaxText + TE runs to a single run command.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
