### PR TITLE
Adapt the latest current-scaling recipe of TE/JAX (Local Amax)

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -530,6 +530,7 @@ class Attention(nnx.Module):
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
         use_bias=self.use_bias_in_projections,
+        using_global_amax_of_x=True,
         rngs=self.rngs,
     )
 
@@ -570,6 +571,7 @@ class Attention(nnx.Module):
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
         use_bias=self.use_bias_in_projections,
+        using_global_amax_of_x=True,
         rngs=self.rngs,
     )
 

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -393,6 +393,7 @@ class MlpBlock(nnx.Module):
           quant=self.quant if self.te_ln_mlp is None else None,
           use_bias=self.use_bias,
           matmul_precision=self.config.matmul_precision,
+          using_global_amax_of_x=True,
           rngs=rngs,
       )
     else:
@@ -409,6 +410,7 @@ class MlpBlock(nnx.Module):
             quant=self.quant if self.te_ln_mlp is None else None,
             use_bias=self.use_bias,
             matmul_precision=self.config.matmul_precision,
+            using_global_amax_of_x=True,
             rngs=rngs,
         )
         setattr(self, dense_name, module)

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -104,6 +104,7 @@ class DenseGeneral(nnx.Module):
       use_bias: bool = False,
       matmul_precision: str = "default",
       parameter_memory_host_offload: bool = False,
+      using_global_amax_of_x: bool = False,
       *,  # Following arguments are keyword-only
       rngs: nnx.Rngs = None,
   ):
@@ -164,7 +165,7 @@ class DenseGeneral(nnx.Module):
       self.bias = None
 
     if quant:
-      dot_general_cls = quant.dot_general_cls(mesh_axes=kernel_axes)
+      dot_general_cls = quant.dot_general_cls(mesh_axes=kernel_axes, using_global_amax_of_x=using_global_amax_of_x)
       dot_general_linen = dot_general_cls()
       quant_dot_general = nnx_wrappers.ToNNX(dot_general_linen, rngs=rngs)
       self._quant_dot_general_name = f"{type(dot_general_linen).__name__}_0"

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -52,7 +52,7 @@ _TILE_SIZE = "tile_size"  # Tile size for subchannel
 class Quantization:
   """Base class for quantization configurations"""
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
     """Placeholder for dot_general implementation in subclasses."""
 
   def einsum(self, dtype: DType = jnp.float32):
@@ -147,7 +147,7 @@ class AqtQuantization:
         _rhs_axis_metadata_wrapper, mesh_axes=mesh_axes, is_tiled=is_tiled, replicate_scale=replicate_scale
     )
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
     """Returns dot_general configured with aqt params."""
     if isinstance(self.quant_dg, dict):
       quant_dg, is_tiled, tiling_fn = self._get_mixed_precision_cfg()
@@ -200,7 +200,7 @@ class Fp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
     """Returns dot_general configured with aqt params."""
     return nn.Fp8DirectDotGeneralOp
 
@@ -292,7 +292,7 @@ class NANOOFp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
     """Returns dot_general configured with aqt params."""
     return nn.NANOOFp8DotGeneralOp
 
@@ -810,13 +810,15 @@ class TransformerEngineQuantization(Quantization):
 
     return TEWrapper
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
     """Placeholder for dot_general implementation in subclasses."""
     import transformer_engine.jax as te
 
-    def te_dot_general(generate_quantizer_set, x, kernel, dims, **kwargs):
+    def te_dot_general(generate_quantizer_set, x, kernel, dims, **inner_kwargs):
       contracting_dims, batch_dims = dims
       assert batch_dims == ((), ()), "Batch dimensions must be empty for TransformerEngine dot."
+
+      using_global_amax_of_x = kwargs.get('using_global_amax_of_x', False)
 
       quantizer_set = generate_quantizer_set()
       return te.dense.dense(

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -52,7 +52,7 @@ _TILE_SIZE = "tile_size"  # Tile size for subchannel
 class Quantization:
   """Base class for quantization configurations"""
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
     """Placeholder for dot_general implementation in subclasses."""
 
   def einsum(self, dtype: DType = jnp.float32):
@@ -147,7 +147,7 @@ class AqtQuantization:
         _rhs_axis_metadata_wrapper, mesh_axes=mesh_axes, is_tiled=is_tiled, replicate_scale=replicate_scale
     )
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
     """Returns dot_general configured with aqt params."""
     if isinstance(self.quant_dg, dict):
       quant_dg, is_tiled, tiling_fn = self._get_mixed_precision_cfg()
@@ -200,7 +200,7 @@ class Fp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
     """Returns dot_general configured with aqt params."""
     return nn.Fp8DirectDotGeneralOp
 
@@ -292,7 +292,7 @@ class NANOOFp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
     """Returns dot_general configured with aqt params."""
     return nn.NANOOFp8DotGeneralOp
 
@@ -810,7 +810,7 @@ class TransformerEngineQuantization(Quantization):
 
     return TEWrapper
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), using_global_amax_of_x: bool = False):
     """Placeholder for dot_general implementation in subclasses."""
     import transformer_engine.jax as te
 
@@ -824,6 +824,7 @@ class TransformerEngineQuantization(Quantization):
         kernel,
         contracting_dims=contracting_dims,
         quantizer_set=quantizer_set,
+        using_global_amax_of_x=using_global_amax_of_x
       )
 
     return self._wrap(te_dot_general, "dot_general")


### PR DESCRIPTION
# Description

- Adding `using_global_amax_of_x` to indicate if needing global-amax across TP/SP axes.

# Tests

Verifed the performance and loss on Llama3.1-70B/8B but reduced layers.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
