### PR TITLE
Revert the changes for amax reduction in CS

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -530,7 +530,6 @@ class Attention(nnx.Module):
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
         use_bias=self.use_bias_in_projections,
-        using_global_amax_of_x=True,
         rngs=self.rngs,
     )
 
@@ -571,7 +570,6 @@ class Attention(nnx.Module):
         quant=self.quant,
         matmul_precision=self.config.matmul_precision,
         use_bias=self.use_bias_in_projections,
-        using_global_amax_of_x=True,
         rngs=self.rngs,
     )
 

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -104,7 +104,6 @@ class DenseGeneral(nnx.Module):
       use_bias: bool = False,
       matmul_precision: str = "default",
       parameter_memory_host_offload: bool = False,
-      using_global_amax_of_x: bool = False,
       *,  # Following arguments are keyword-only
       rngs: nnx.Rngs = None,
   ):
@@ -165,7 +164,7 @@ class DenseGeneral(nnx.Module):
       self.bias = None
 
     if quant:
-      dot_general_cls = quant.dot_general_cls(mesh_axes=kernel_axes, using_global_amax_of_x=using_global_amax_of_x)
+      dot_general_cls = quant.dot_general_cls(mesh_axes=kernel_axes)
       dot_general_linen = dot_general_cls()
       quant_dot_general = nnx_wrappers.ToNNX(dot_general_linen, rngs=rngs)
       self._quant_dot_general_name = f"{type(dot_general_linen).__name__}_0"
@@ -393,7 +392,6 @@ class MlpBlock(nnx.Module):
           quant=self.quant if self.te_ln_mlp is None else None,
           use_bias=self.use_bias,
           matmul_precision=self.config.matmul_precision,
-          using_global_amax_of_x=True,
           rngs=rngs,
       )
     else:
@@ -410,7 +408,6 @@ class MlpBlock(nnx.Module):
             quant=self.quant if self.te_ln_mlp is None else None,
             use_bias=self.use_bias,
             matmul_precision=self.config.matmul_precision,
-            using_global_amax_of_x=True,
             rngs=rngs,
         )
         setattr(self, dense_name, module)

--- a/MaxText/layers/quantizations.py
+++ b/MaxText/layers/quantizations.py
@@ -52,7 +52,7 @@ _TILE_SIZE = "tile_size"  # Tile size for subchannel
 class Quantization:
   """Base class for quantization configurations"""
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Placeholder for dot_general implementation in subclasses."""
 
   def einsum(self, dtype: DType = jnp.float32):
@@ -147,7 +147,7 @@ class AqtQuantization:
         _rhs_axis_metadata_wrapper, mesh_axes=mesh_axes, is_tiled=is_tiled, replicate_scale=replicate_scale
     )
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Returns dot_general configured with aqt params."""
     if isinstance(self.quant_dg, dict):
       quant_dg, is_tiled, tiling_fn = self._get_mixed_precision_cfg()
@@ -200,7 +200,7 @@ class Fp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Returns dot_general configured with aqt params."""
     return nn.Fp8DirectDotGeneralOp
 
@@ -292,7 +292,7 @@ class NANOOFp8Quantization(Quantization):
 
   quant_mode = "train"
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Returns dot_general configured with aqt params."""
     return nn.NANOOFp8DotGeneralOp
 
@@ -810,15 +810,13 @@ class TransformerEngineQuantization(Quantization):
 
     return TEWrapper
 
-  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = (), **kwargs):
+  def dot_general_cls(self, mesh_axes: Tuple[str, ...] = ()):
     """Placeholder for dot_general implementation in subclasses."""
     import transformer_engine.jax as te
 
-    def te_dot_general(generate_quantizer_set, x, kernel, dims, **inner_kwargs):
+    def te_dot_general(generate_quantizer_set, x, kernel, dims, **kwargs):
       contracting_dims, batch_dims = dims
       assert batch_dims == ((), ()), "Batch dimensions must be empty for TransformerEngine dot."
-
-      using_global_amax_of_x = kwargs.get('using_global_amax_of_x', False)
 
       quantizer_set = generate_quantizer_set()
       return te.dense.dense(
@@ -826,7 +824,6 @@ class TransformerEngineQuantization(Quantization):
         kernel,
         contracting_dims=contracting_dims,
         quantizer_set=quantizer_set,
-        using_global_amax_of_x=using_global_amax_of_x
       )
 
     return self._wrap(te_dot_general, "dot_general")


### PR DESCRIPTION
This reverts commit 0e22d6464ed6224ff05d545d452c91544f0518d9, reversing changes made to a4e9561d69d1a2db94c6be09912bd165430b9e82.

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a bug or a Github issue, please include a link, e.g.,:
FIXES: b/123456
FIXES: #123456

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed.
