### PR TITLE
[JAX] Support checkpointing TE quantizations with new remat policies

### DIFF
--- a/src/MaxText/layers/decoders.py
+++ b/src/MaxText/layers/decoders.py
@@ -18,6 +18,7 @@
 
 from typing import Any
 import functools
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -261,7 +262,7 @@ class Decoder(nn.Module):
           config=self.config, mesh=self.mesh, layers=pipeline_stage_module, remat_policy=remat_policy
       )
 
-  def minimal_policy(self, with_context=False):
+  def minimal_policy(self, with_context=False, with_quantization=False):
     """Helper for creating minimal checkpoint policies."""
     names = [
         "query_proj",
@@ -276,6 +277,8 @@ class Decoder(nn.Module):
     ]
     if with_context:
       names.append("context")
+    if with_quantization:
+      names.append("quantization")
     return jax.checkpoint_policies.save_only_these_names(*names)
 
   def get_remat_policy(self):
@@ -292,6 +295,14 @@ class Decoder(nn.Module):
       elif cfg.remat_policy == "minimal":
         # save all except context
         policy = self.minimal_policy()
+      elif cfg.remat_policy == "minimal_with_quantization":
+        if cfg.scan_layers:
+          warnings.warn('Scan layers can introduce overhead to checkpointed values that in some configurations is slower than not checkpointing at all. If you are using scan layers, benchmark with and without quantization checkpointing in your workflow to see which is faster. Without scan layers, checkpointing quantizations is beneficial for performance.')
+        policy = self.minimal_policy(with_context=False, with_quantization=True)
+      elif cfg.remat_policy == "minimal_with_context_and_quantization":
+        if cfg.scan_layers:
+          warnings.warn('Scan layers can introduce overhead to checkpointed values that in some configurations is slower than not checkpointing at all. If you are using scan layers, benchmark with and without quantization checkpointing in your workflow to see which is faster. Without scan layers, checkpointing quantizations is beneficial for performance.')
+        policy = self.minimal_policy(with_context=True, with_quantization=True)
       elif cfg.remat_policy == "save_dot_with_context_except_mlp":
         policy = jax.checkpoint_policies.save_only_these_names(
             "query_proj",

--- a/src/MaxText/layers/quantizations.py
+++ b/src/MaxText/layers/quantizations.py
@@ -750,6 +750,7 @@ class TransformerEngineQuantization(Quantization):
       "te_fp8_delayedscaling": recipe.DelayedScaling,
       "te_fp8_currentscaling": recipe.Float8CurrentScaling,
       "te_mxfp8": recipe.MXFP8BlockScaling,
+      "te_nvfp4": recipe.NVFP4BlockScaling,
     }
     if recipe_name not in RECIPES:
       raise ValueError(f"Invalid TransformerEngine recipe: {recipe_name}")
@@ -763,6 +764,9 @@ class TransformerEngineQuantization(Quantization):
     from transformer_engine.common import recipe
     if isinstance(self._recipe, recipe.MXFP8BlockScaling):
       return 32
+    if isinstance(self._recipe, recipe.NVFP4BlockScaling):
+      # TODO(jberchtold): reduce to 16 when unfused RHT is supported
+      return 64
     return 1
 
   def _wrap(self, f, name = None):
@@ -792,7 +796,12 @@ class TransformerEngineQuantization(Quantization):
     class TEWrapper(te.flax.module.TransformerEngineBase):
       def generate_quantizer_set(self, postfix: str = ""):
         OVERWRITE_WITH_GRADIENT = "_overwrite_with_gradient"
-        return super().generate_quantizer_set(postfix=postfix, variable_collection=OVERWRITE_WITH_GRADIENT, fp8_recipe=fp8_recipe)
+        return super().generate_quantizer_set(
+          postfix=postfix,
+          variable_collection=OVERWRITE_WITH_GRADIENT,
+          quantization_checkpoint_name="quantization",
+          fp8_recipe=fp8_recipe,
+        )
 
       @nn.compact
       def __call__(self, *args, **kwargs):


### PR DESCRIPTION
# Description

This PR adds two new remat policies `minimal_with_quantization` and `minimal_with_context_and_quantization` which extend the existing remat policies with support for TE quantization. Checkpointing these quantizations can give a significant performance benefit by using TE's fused rowwise+colwise kernels and avoiding recompute.

```
for all configs: scan_layers=false, llama3.1-8b, single GB200

fused_mlp=true, remat=minimal: 19980 tokens/s
fused_mlp=true, remat=minimal_with_quantization: 22500 tokens/s
fused_mlp=true, remat=minimal_with_context: 20250 tokens/s
fused_mlp=true, remat=minimal_with_context_and_quantization: 22700 tokens/s

fused_mlp=false, remat=minimal: 20000 tokens/s
fused_mlp=false, remat=minimal_with_quantization: 22700 tokens/s
fused_mlp=false, remat=minimal_with_context: 20200 tokens/s
fused_mlp=false, remat=minimal_with_context_and_quantization: 22950 tokens/s
```

When scan is enabled, it can introduce some overhead when checkpointing values. In some cases, this overhead outweights the benefits of avoiding recompute here, so a warning is printed if these policies are added while MaxText scan layers are enabled.
