### PR TITLE
[TE] Integrate TE router 

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -191,6 +191,7 @@ use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backw
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
 te_permutation_impl: false # whether to use TransformerEngine permutation kernels for MoE token dispatch/combine
 te_permutation_align_size: 128 # alignment size for TE permutation padding, set to 0 to disable padding
+te_router_impl: false # whether to use TransformerEngine fused router kernels for MoE routing
 # tunable tiling dimensions used for mlp gmm
 # megablox/jax ragged dot - supports forward pass only (6 configs: `wi_tile_fwd...` and `wo_tile_fwd_...`)
 # tokamax ragged dot - supports all 18 configs

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -189,9 +189,8 @@ load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
-te_permutation_impl: false # whether to use TransformerEngine permutation kernels for MoE token dispatch/combine
+te_permutation_impl: false # whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine
 te_permutation_align_size: 128 # alignment size for TE permutation padding, set to 0 to disable padding
-te_router_impl: false # whether to use TransformerEngine fused router kernels for MoE routing
 # tunable tiling dimensions used for mlp gmm
 # megablox/jax ragged dot - supports forward pass only (6 configs: `wi_tile_fwd...` and `wo_tile_fwd_...`)
 # tokamax ragged dot - supports all 18 configs

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -189,7 +189,7 @@ load_balance_loss_weight: 0.0 # weight for the load balance loss
 use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
-te_permutation_impl: false # whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine
+te_router_and_permutation_impl: false # whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine
 te_permutation_align_size: 128 # alignment size for TE permutation padding, set to 0 to disable padding
 # tunable tiling dimensions used for mlp gmm
 # megablox/jax ragged dot - supports forward pass only (6 configs: `wi_tile_fwd...` and `wo_tile_fwd_...`)

--- a/src/maxtext/configs/models/mixtral-8x7b.yml
+++ b/src/maxtext/configs/models/mixtral-8x7b.yml
@@ -20,7 +20,7 @@ base_num_query_heads: 32
 base_num_kv_heads: 8
 base_mlp_dim: 14336
 base_moe_mlp_dim: 14336
-base_num_decoder_layers: 32
+base_num_decoder_layers: 1
 head_dim: 128
 mlp_activations: ["silu","linear"]
 vocab_size: 32000

--- a/src/maxtext/configs/models/mixtral-8x7b.yml
+++ b/src/maxtext/configs/models/mixtral-8x7b.yml
@@ -20,7 +20,7 @@ base_num_query_heads: 32
 base_num_kv_heads: 8
 base_mlp_dim: 14336
 base_moe_mlp_dim: 14336
-base_num_decoder_layers: 1
+base_num_decoder_layers: 32
 head_dim: 128
 mlp_activations: ["silu","linear"]
 vocab_size: 32000

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -619,6 +619,10 @@ class MoEGeneral(BaseModel):
       128,
       description="Alignment size for TE permutation padding. Set to 0 to disable padding.",
   )
+  te_router_impl: bool = Field(
+      False,
+      description="Whether to use TransformerEngine fused router kernels for MoE routing. Requires te_permutation_impl=True.",
+  )
   use_random_routing: bool = Field(False, description="Whether to use random routing for debugging.")
   interleave_moe_layer_step: int = Field(1, description="Frequency of MoE layers, e.g., 2 means every 2nd layer is MoE.")
   expert_shard_attention_option: Literal["fsdp", "context"] = Field(
@@ -2382,6 +2386,14 @@ class MaxTextConfig(
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
       if self.routed_bias and self.routed_bias_update_rate > 0.0 and self.decoder_block != DecoderBlockType.DEEPSEEK:
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
+      if self.te_router_impl:
+        if not self.te_permutation_impl:
+          raise ValueError(
+              "te_router_impl=True requires te_permutation_impl=True. "
+              "The TE fused router outputs (sparse_probs, routing_map) are only compatible with TE permutation."
+          )
+        if not self.sparse_matmul:
+          raise ValueError("te_router_impl=True requires sparse_matmul=True.")
     if self.use_multimodal:
       valid_mm_models = (
           "gemma3-4b",

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -611,7 +611,7 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use Ring of Experts for sparse matmul expert parallelism.",
   )
-  te_permutation_impl: bool = Field(
+  te_router_and_permutation_impl: bool = Field(
       False,
       description="Whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine.",
   )
@@ -2382,8 +2382,8 @@ class MaxTextConfig(
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
       if self.routed_bias and self.routed_bias_update_rate > 0.0 and self.decoder_block != DecoderBlockType.DEEPSEEK:
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
-      if self.te_permutation_impl and not self.sparse_matmul:
-        raise ValueError("te_permutation_impl=True requires sparse_matmul=True.")
+      if self.te_router_and_permutation_impl and not self.sparse_matmul:
+        raise ValueError("te_router_and_permutation_impl=True requires sparse_matmul=True.")
     if self.use_multimodal:
       valid_mm_models = (
           "gemma3-4b",

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -613,15 +613,11 @@ class MoEGeneral(BaseModel):
   )
   te_permutation_impl: bool = Field(
       False,
-      description="Whether to use TransformerEngine permutation kernels for MoE token dispatch/combine.",
+      description="Whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine.",
   )
   te_permutation_align_size: int = Field(
       128,
       description="Alignment size for TE permutation padding. Set to 0 to disable padding.",
-  )
-  te_router_impl: bool = Field(
-      False,
-      description="Whether to use TransformerEngine fused router kernels for MoE routing. Requires te_permutation_impl=True.",
   )
   use_random_routing: bool = Field(False, description="Whether to use random routing for debugging.")
   interleave_moe_layer_step: int = Field(1, description="Frequency of MoE layers, e.g., 2 means every 2nd layer is MoE.")
@@ -2386,14 +2382,8 @@ class MaxTextConfig(
         raise ValueError("GPT-OSS MoE only supports dropless (capacity_factor=-1) with dense matmul.")
       if self.routed_bias and self.routed_bias_update_rate > 0.0 and self.decoder_block != DecoderBlockType.DEEPSEEK:
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
-      if self.te_router_impl:
-        if not self.te_permutation_impl:
-          raise ValueError(
-              "te_router_impl=True requires te_permutation_impl=True. "
-              "The TE fused router outputs (sparse_probs, routing_map) are only compatible with TE permutation."
-          )
-        if not self.sparse_matmul:
-          raise ValueError("te_router_impl=True requires sparse_matmul=True.")
+      if self.te_permutation_impl and not self.sparse_matmul:
+        raise ValueError("te_permutation_impl=True requires sparse_matmul=True.")
     if self.use_multimodal:
       valid_mm_models = (
           "gemma3-4b",

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -872,8 +872,12 @@ class RoutedMoE(nnx.Module):
 
     raw_logits_2d = gate_logits.reshape(num_tokens, -1)
 
-    # ---- Launch both kernels before consuming either's output ----
-    # Main routing: score_func -> [bias] -> top-k -> [post-softmax] -> scale
+    router_dtype = jnp.float32 if self.config.logits_dot_in_fp32 else self.dtype
+    raw_logits_2d = raw_logits_2d.astype(router_dtype)
+    expert_bias_for_te = None
+    if gate_expert_bias is not None and gate_expert_bias.size > 0:
+      expert_bias_for_te = gate_expert_bias.astype(router_dtype)
+
     sparse_probs, routing_map = te_router.te_fused_topk(
         raw_logits_2d,
         topk=self.num_experts_per_tok,
@@ -882,8 +886,11 @@ class RoutedMoE(nnx.Module):
         num_groups=self.config.n_routing_groups,
         group_topk=self.config.topk_routing_group,
         scaling_factor=self.config.routed_scaling_factor,
-        expert_bias=gate_expert_bias if gate_expert_bias is not None and gate_expert_bias.size > 0 else None,
+        expert_bias=expert_bias_for_te,
     )
+
+    sparse_probs = sparse_probs.astype(self.dtype)
+
     # Aux scoring: score_func -> top-k (clean — no bias/groups/scaling)
     aux_scores, aux_routing_map = None, None
     if self.config.load_balance_loss_weight > 0.0:
@@ -904,6 +911,7 @@ class RoutedMoE(nnx.Module):
           topk=self.num_experts_per_tok,
           coeff=self.config.load_balance_loss_weight,
       )
+      aux_scores = aux_scores.astype(self.dtype)
 
     # Bias updates use the main routing_map (actual load after bias).
     bias_updates = None
@@ -1003,6 +1011,7 @@ class RoutedMoE(nnx.Module):
       x, perm_state.row_id_map, group_sizes, perm_state.dense_probs, perm_state.pad_offsets = (
           self._te_permute(inputs, routing_map, dense_probs)
       )
+
       expert_indices = jnp.arange(self.num_experts)
       selected_experts = jnp.repeat(
           expert_indices, repeats=group_sizes, total_repeat_length=x.shape[0],

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -34,6 +34,7 @@ from maxtext.common.common_types import ShardMode
 from maxtext.layers import attentions, linears, nnx_wrappers, quantizations
 from maxtext.layers.initializers import NdInitializer, default_bias_init, nd_dense_init, variable_to_logically_partitioned
 from maxtext.layers import te_permutation
+from maxtext.layers import te_router
 from maxtext.kernels import megablox as mblx
 from maxtext.utils import max_logging
 from maxtext.utils import max_utils
@@ -304,7 +305,12 @@ class GateLogit(nnx.Module):
       return None
     return getattr(self, self._quant_dot_general_name)
 
-  def __call__(self, inputs: jax.Array, _initializing: bool = False) -> Tuple[jax.Array, Optional[jax.Array]]:
+  def __call__(
+      self,
+      inputs: jax.Array,
+      _initializing: bool = False,
+      return_raw_logits: bool = False,
+  ) -> Tuple[jax.Array, Optional[jax.Array]]:
 
     inputs = jnp.asarray(inputs, self.dtype)
     norm_axis = linears.normalize_axes(self.axis, inputs.ndim)
@@ -332,6 +338,10 @@ class GateLogit(nnx.Module):
         _initializing,
         out_sharding=output_sharding,
     )
+
+    if return_raw_logits:
+      return output, None
+
     pre_bias_logits = None
 
     if self.score_func:
@@ -648,43 +658,44 @@ class RoutedMoE(nnx.Module):
         intermediate_layer = jnp.multiply(layer_act, layer_w1)
       return intermediate_layer.astype(self.dtype)
 
-  def _mt_permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None, roll_to_expert_id=None):
-    """MaxText permute: sort tokens by expert using argsort."""
-    # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
+  def _mt_permute(self, inputs, weights, selected_experts, use_custom_sort_vjp=True, roll_to_expert_id=None):
+    """Pure MaxText token permutation — no routing logic.
+
+    Sorts tokens by expert assignment using argsort. All routing decisions
+    (which experts, what weights) must be made before calling this method.
+
+    Args:
+      inputs: Input tensor of shape [batch, seq, hidden].
+      weights: Routing weights [batch, seq, num_experts_per_tok].
+      selected_experts: Top-k expert indices [batch, seq, num_experts_per_tok].
+      use_custom_sort_vjp: Whether to use custom sort VJP.
+      roll_to_expert_id: Expert ID offset for ring-of-experts.
+
+    Returns:
+      Tuple of:
+        - sorted_inputs: Tokens sorted by expert [num_out_tokens, hidden].
+        - sorted_selected_experts: Sort indices for unpermute.
+        - weights: Routing weights (passed through for unpermute).
+        - group_size: Token counts per expert [num_experts].
+        - sorted_experts: Expert ID for each sorted token position.
+    """
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
-    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
-
-    lb_loss = None
-    if self.config.load_balance_loss_weight > 0.0:
-      softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
-      lb_loss = self.load_balance_loss(selected_experts, softmax_probs)
-
-    if self.should_update_load_balance():
-      bias_updates = calculate_load_balance_updates(
-          selected_experts, self.config.num_experts, self.config.routed_bias_update_rate
-      )
-    else:
-      bias_updates = None
 
     if self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4:
-      # weights will be of shape (batch_size, seq_len, num_experts_per_tok)
-      router_scores = jax.nn.sigmoid(weights.astype(jnp.float32))  # weights are top_k_weights here
-      # Squeeze router_scores to (batch_size * seq_len, num_experts_per_tok)
+      router_scores = jax.nn.sigmoid(weights.astype(jnp.float32))
       inputs_2d = inputs_2d * router_scores.reshape(bsz_times_seq_len, -1)
 
     flatten_selected_experts = jnp.ravel(selected_experts)
     if roll_to_expert_id is not None:
       flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
     sorted_selected_experts = jnp.argsort(flatten_selected_experts)
-    # sort inputs for number of selected experts
     replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
     sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
         self.dtype
     )
     group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
-    # Return the experts for each sorted input.
     expert_indices = jnp.arange(self.num_experts)
     sorted_experts = jnp.repeat(
         expert_indices,
@@ -697,114 +708,43 @@ class RoutedMoE(nnx.Module):
         weights,
         group_size,
         sorted_experts,
-        lb_loss,
-        bias_updates,
     )
 
   def _te_permute(
       self,
       inputs: jax.Array,
-      gate_logits: jax.Array,
-      pre_bias_logits: Optional[jax.Array],
-      rngs=None,
-      roll_to_expert_id=None,
-  ) -> Tuple[
-      jax.Array,
-      jax.Array,
-      jax.Array,
-      jax.Array,
-      jax.Array,
-      jax.Array,
-      Optional[jax.Array],
-      Optional[jax.Array],
-      jax.Array,
-      Optional[jax.Array],
-  ]:
-    """Permute tokens to group by expert using TransformerEngine kernels.
+      routing_map: jax.Array,
+      dense_probs: jax.Array,
+  ) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array, Optional[jax.Array]]:
+    """Pure TE token dispatch — no routing logic.
 
-    This is an alternative to the standard permute() method that uses TE's
-    optimized Triton kernels for token dispatch.
+    Rearranges tokens by expert using TransformerEngine's optimized kernels.
+    All routing decisions (which experts, what weights) must be made before
+    calling this method.
 
     Args:
-      inputs: Input tensor of shape [batch, seq, hidden].
-      gate_logits: Router logits of shape [batch, seq, num_experts].
-      pre_bias_logits: Pre-bias logits for DeepSeek models, or None.
-      rngs: Random number generators for dropout (if any).
+      inputs: Input tensor of shape [batch, seq, hidden] or [num_tokens, hidden].
+      routing_map: Boolean routing mask [num_tokens, num_experts].
+      dense_probs: Dense routing probs [num_tokens, num_experts].
 
     Returns:
       Tuple of:
-        - permuted_inputs: Tokens sorted by expert [num_out_tokens, hidden].
+        - permuted_outputs: Tokens grouped by expert [num_out_tokens, hidden].
         - row_id_map: Mapping for unpermute phase.
-        - weights: Routing weights [batch, seq, num_experts_per_tok].
-        - tokens_per_expert: Token counts per expert [num_experts] (aligned if padding enabled).
-        - top_k_indices: Selected expert indices [batch, seq, num_experts_per_tok].
-        - lb_loss: Load balance loss (or None).
-        - bias_updates: Bias updates (or None).
-        - dense_probs: Dense routing probs [num_tokens, num_experts] for combine.
-        - pad_offsets: Padding offsets per expert [num_experts] (or None).
-
-    Note on probs flow:
-      - weights from get_topk() are already softmaxed over the top-k experts
-      - We convert to dense_probs [num_tokens, num_experts] once here
-      - TE token_combine uses dense_probs directly as merging_probs (no further softmax)
-      - This avoids redundant computation of dense_probs in te_unpermute()
+        - tokens_per_expert: Token counts per expert [num_experts].
+        - dense_probs: Dense routing probs (passed through for unpermute).
+        - pad_offsets: Padding offsets per expert (or None).
     """
     te_permutation.check_te_permutation_available()
 
-    inputs_shape = inputs.shape
-    batch_size = inputs_shape[0]
-    seq_len = inputs_shape[1]
-    hidden_size = inputs_shape[2]
-    num_tokens = batch_size * seq_len
-
-    # Get top-k routing decisions
-    # Note: weights are already softmaxed over the k selected experts in get_topk()
-    weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, rngs)
-
-    # Compute load balance loss if configured
-    lb_loss = None
-    if self.config.load_balance_loss_weight > 0.0:
-      softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
-      lb_loss = self.load_balance_loss(top_k_indices, softmax_probs)
-
-    # Compute bias updates if needed
-    if self.should_update_load_balance():
-      bias_updates = calculate_load_balance_updates(
-          top_k_indices, self.config.num_experts, self.config.routed_bias_update_rate
-      )
-    else:
-      bias_updates = None
-
-    # For ring-of-experts: shift expert indices so each shard's local experts
-    # become 0..local_expert_size-1 (same as MT's roll logic)
-    if roll_to_expert_id is not None:
-      top_k_indices = (top_k_indices - roll_to_expert_id) % self.num_experts
-
-    # Convert indices to routing map (binary mask)
-    routing_map = te_permutation.create_routing_map_from_indices(
-        top_k_indices, self.num_experts
-    )
-
-    # Create dense probs from top-k weights for TE dispatch AND combine
-    # Shape: [num_tokens, num_experts] where probs[i, j] is the routing prob
-    # for token i to expert j (0 for non-selected experts)
-    # These are already normalized (softmax over top-k in get_topk), so TE
-    # can use them directly as merging_probs without further processing.
-    dense_probs = te_permutation.create_dense_probs_from_topk(
-        weights, top_k_indices, self.num_experts
-    )
-
-    # Number of output tokens
+    hidden_size = inputs.shape[-1]
+    num_tokens = routing_map.shape[0]
     num_out_tokens = num_tokens * self.num_experts_per_tok
 
-    # Get align_size from config (0 means no padding)
     align_size = self.config.te_permutation_align_size
     if align_size == 0:
       align_size = None
 
-    # Call TE token dispatch with probs and padding
-    # Note: We pass dense_probs to dispatch (for permuting alongside tokens),
-    # and also return it for use as merging_probs in te_unpermute (combine).
     permuted_outputs, _permuted_probs, row_id_map, pad_offsets, tokens_per_expert = te_permutation.te_token_dispatch(
         inputs.reshape(-1, hidden_size),
         routing_map,
@@ -813,17 +753,7 @@ class RoutedMoE(nnx.Module):
         align_size=align_size,
     )
 
-    return (
-        permuted_outputs,
-        row_id_map,
-        weights,
-        tokens_per_expert,  # Token counts per expert (aligned to align_size if padding enabled)
-        top_k_indices,
-        lb_loss,
-        bias_updates,
-        dense_probs,  # Return dense_probs for reuse in te_unpermute
-        pad_offsets,
-    )
+    return permuted_outputs, row_id_map, tokens_per_expert, dense_probs, pad_offsets
 
   def _te_unpermute(
       self,
@@ -916,37 +846,173 @@ class RoutedMoE(nnx.Module):
       )
     return output.reshape(batch_size, sequence_length, -1).astype(self.dtype)
 
-  def permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None, roll_to_expert_id=None):
-    """Permute tokens to group by expert. Dispatches to TE or MT implementation.
+  def _te_route(self, gate_logits, gate_expert_bias, num_tokens, roll_to_expert_id=None):
+    """TE router: fused score_function + top-k + bias + scaling.
+
+    Wraps all TE routing logic including the fused top-k kernel,
+    auxiliary loss computation, and bias updates.
+
+    The main routing kernel and aux scoring kernel are logically independent
+    (both read only from raw_logits_2d with no data dependency between them),
+    so XLA can overlap their GPU execution automatically.
+
+    Args:
+      gate_logits: Raw GEMM logits [batch, seq, num_experts] (no score_func/bias).
+      gate_expert_bias: Expert bias [num_experts] or empty array [0].
+      num_tokens: Total number of tokens (batch * seq).
+      roll_to_expert_id: Expert ID offset for ring-of-experts.
 
     Returns:
-      Tuple of (x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates).
-      - x: Permuted tokens [num_out_tokens, hidden].
-      - perm_state: PermState carrying implementation-specific state for unpermute.
-      - group_sizes: Token counts per expert [num_experts].
-      - selected_experts: Expert ID for each token position [num_out_tokens].
-      - lb_loss: Load balance loss (or None).
-      - bias_updates: Bias updates (or None).
+      routing_map: Boolean routing mask [num_tokens, num_experts].
+      dense_probs: Sparse probs as dense [num_tokens, num_experts] for TE combine.
+      lb_loss: Scalar load balance loss or None.
+      bias_updates: Bias update direction [num_experts] or None.
     """
-    use_te = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE
-    perm_state = PermState(use_te)
+    te_router.check_te_router_available()
 
-    if use_te:
-      # TE permutation path
-      (
-          x, perm_state.row_id_map, weights, group_sizes, top_k_indices,
-          lb_loss, bias_updates, perm_state.dense_probs, perm_state.pad_offsets,
-      ) = self._te_permute(inputs, gate_logits, pre_bias_logits, rngs, roll_to_expert_id)
-      # Create selected_experts for bias transform and GMM
+    raw_logits_2d = gate_logits.reshape(num_tokens, -1)
+
+    # ---- Launch both kernels before consuming either's output ----
+    # Main routing: score_func -> [bias] -> top-k -> [post-softmax] -> scale
+    sparse_probs, routing_map = te_router.te_fused_topk(
+        raw_logits_2d,
+        topk=self.num_experts_per_tok,
+        score_function=self.config.routed_score_func,
+        use_pre_softmax=False,
+        num_groups=self.config.n_routing_groups,
+        group_topk=self.config.topk_routing_group,
+        scaling_factor=self.config.routed_scaling_factor,
+        expert_bias=gate_expert_bias if gate_expert_bias is not None and gate_expert_bias.size > 0 else None,
+    )
+    # Aux scoring: score_func -> top-k (clean — no bias/groups/scaling)
+    aux_scores, aux_routing_map = None, None
+    if self.config.load_balance_loss_weight > 0.0:
+      aux_scores, aux_routing_map = te_router.te_compute_aux_scores(
+          raw_logits_2d,
+          topk=self.num_experts_per_tok,
+          score_function=self.config.routed_score_func,
+      )
+
+    # ---- Derive outputs from kernel results ----
+    # Aux loss uses the clean aux_routing_map (no bias influence) for
+    # tokens_per_expert, keeping the entire loss path bias-free.
+    lb_loss = None
+    if self.config.load_balance_loss_weight > 0.0:
+      aux_tokens_per_expert = jnp.sum(aux_routing_map.astype(jnp.int32), axis=0)
+      lb_loss = te_router.te_aux_loss(
+          aux_scores, aux_tokens_per_expert,
+          topk=self.num_experts_per_tok,
+          coeff=self.config.load_balance_loss_weight,
+      )
+
+    # Bias updates use the main routing_map (actual load after bias).
+    bias_updates = None
+    if self.should_update_load_balance():
+      main_tokens_per_expert = jnp.sum(routing_map.astype(jnp.int32), axis=0)
+      total_assignments = num_tokens * self.num_experts_per_tok
+      average_load = total_assignments / self.num_experts
+      direction = jnp.sign(average_load - main_tokens_per_expert)
+      bias_updates = direction * self.config.routed_bias_update_rate
+
+    # Roll for ring-of-experts
+    if roll_to_expert_id is not None:
+      routing_map = jnp.roll(routing_map, -roll_to_expert_id, axis=-1)
+      sparse_probs = jnp.roll(sparse_probs, -roll_to_expert_id, axis=-1)
+
+    return routing_map, sparse_probs, lb_loss, bias_updates
+
+  def permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None,
+              roll_to_expert_id=None, gate_expert_bias=None):
+    """Permute tokens to group by expert.
+
+    Routing and permutation are fully decoupled:
+
+    Step 1 — Routing (top level, independent of permutation):
+      - TE router: _te_route() → (routing_map, dense_probs, lb_loss, bias_updates)
+      - MT router: get_topk() → (weights, top_k_indices) + lb_loss + bias_updates
+
+    Step 2 — Permutation (pure token rearrangement):
+      - TE permute: _te_permute(inputs, routing_map, dense_probs)
+      - MT permute: _mt_permute(inputs, weights, top_k_indices, ...)
+
+    Returns:
+      Tuple of (x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates):
+        - x: Permuted tokens [num_out_tokens, hidden].
+        - perm_state: PermState carrying implementation-specific state for unpermute.
+        - group_sizes: Token counts per expert [num_experts].
+        - selected_experts: Expert ID for each token position [num_out_tokens].
+        - lb_loss: Scalar load balance loss (or None).
+        - bias_updates: Bias update direction [num_experts] (or None).
+    """
+    use_te_perm = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE
+    use_te_rtr = getattr(self.config, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
+    perm_state = PermState(use_te_perm)
+
+    num_tokens = inputs.shape[0] * inputs.shape[1]
+
+    # =========================================================================
+    # Step 1: Routing — produces routing decisions, lb_loss, bias_updates
+    # =========================================================================
+    if use_te_rtr:
+      if not use_te_perm:
+        raise ValueError(
+            "te_router_impl=True requires te_permutation_impl=True. "
+            "The TE router outputs (sparse_probs, routing_map) are only compatible "
+            "with TE permutation."
+        )
+
+      routing_map, dense_probs, lb_loss, bias_updates = self._te_route(
+          gate_logits, gate_expert_bias, num_tokens, roll_to_expert_id,
+      )
+      weights = None
+      top_k_indices = None
+
+    else:
+      # --- MT Router (get_topk) ---
+      weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, rngs)
+
+      lb_loss = None
+      if self.config.load_balance_loss_weight > 0.0:
+        softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
+        lb_loss = self.load_balance_loss(top_k_indices, softmax_probs)
+
+      bias_updates = None
+      if self.should_update_load_balance():
+        bias_updates = calculate_load_balance_updates(
+            top_k_indices, self.config.num_experts, self.config.routed_bias_update_rate
+        )
+
+      routing_map = None
+      dense_probs = None
+
+    # =========================================================================
+    # Step 2: Permutation — pure token rearrangement
+    # =========================================================================
+    if use_te_perm:
+      # Convert MT router outputs to TE format if needed
+      if routing_map is None:
+        if roll_to_expert_id is not None:
+          top_k_indices = (top_k_indices - roll_to_expert_id) % self.num_experts
+        routing_map = te_permutation.create_routing_map_from_indices(
+            top_k_indices, self.num_experts
+        )
+        dense_probs = te_permutation.create_dense_probs_from_topk(
+            weights, top_k_indices, self.num_experts
+        )
+
+      x, perm_state.row_id_map, group_sizes, perm_state.dense_probs, perm_state.pad_offsets = (
+          self._te_permute(inputs, routing_map, dense_probs)
+      )
       expert_indices = jnp.arange(self.num_experts)
       selected_experts = jnp.repeat(
           expert_indices, repeats=group_sizes, total_repeat_length=x.shape[0],
       )
       perm_state.weights = weights
+
     else:
-      # MT permutation path
-      x, perm_state.sorted_selected_experts, perm_state.weights, group_sizes, selected_experts, lb_loss, bias_updates = (
-          self._mt_permute(inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp, rngs, roll_to_expert_id)
+      # MT permutation (MT router only — TE router requires TE perm)
+      x, perm_state.sorted_selected_experts, perm_state.weights, group_sizes, selected_experts = (
+          self._mt_permute(inputs, weights, top_k_indices, use_custom_sort_vjp, roll_to_expert_id)
       )
 
     return x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates
@@ -1374,6 +1440,14 @@ class RoutedMoE(nnx.Module):
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
+    # Extract gate expert bias internally when TE router is active.
+    # This avoids exposing gate_expert_bias in the public API.
+    use_te_rtr = getattr(self.config, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
+    if use_te_rtr and hasattr(self, 'gate') and self.gate.use_bias:
+      gate_expert_bias = jnp.asarray(self.gate.bias[...], self.dtype)
+    else:
+      gate_expert_bias = jnp.empty((0,), dtype=self.dtype)
+
     def gmm(
         inputs, kernel, tiling, group_sizes, expert_assignments, weight_gather_axes, input_buffer_count, combine_scopes
     ):
@@ -1570,6 +1644,7 @@ class RoutedMoE(nnx.Module):
             w1_bias_pspec,
             wo_bias_pspec,
             P(),  # Replicate the input key
+            P(),  # gate_expert_bias (replicated)
         ),
         out_specs=(
             self._logical_to_mesh_axes((batch_logical_axis, "activation_norm_length", "activation_embed")),
@@ -1578,7 +1653,7 @@ class RoutedMoE(nnx.Module):
         ),
         check_vma=False,
     )
-    def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs):
+    def wrapper(x, logits, pre_bias_logits, w0, w1, wo, w0_bias, w1_bias, wo_bias, rngs, gate_expert_bias):
       batch_size, sequence_length, _ = x.shape
       num_expert_parallelism = self.get_expert_parallelism_size()
       if num_expert_parallelism > 1:
@@ -1602,6 +1677,7 @@ class RoutedMoE(nnx.Module):
         x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates = self.permute(
             x, logits, pre_bias_logits, self.config.use_custom_sort_vjp,
             roll_to_expert_id=num_experts_per_shard * expert_shard_id,
+            gate_expert_bias=gate_expert_bias,
         )
 
         # Filter down to the group sizes that apply to only the experts in the
@@ -1615,6 +1691,7 @@ class RoutedMoE(nnx.Module):
         # =======================================================================
         x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates = self.permute(
             x, logits, pre_bias_logits, self.config.use_custom_sort_vjp, rngs,
+            gate_expert_bias=gate_expert_bias,
         )
         use_te_perm = perm_state.use_te
 
@@ -1927,7 +2004,8 @@ class RoutedMoE(nnx.Module):
     pre_bias_logits = self._maybe_shard_with_logical(pre_bias_logits, pre_bias_logits_axes)
 
     return wrapper(
-        inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias, self.rngs
+        inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias, self.rngs,
+        gate_expert_bias,
     )
 
   def reshape_and_update_weights(self, weights, indices):
@@ -2505,7 +2583,14 @@ class RoutedMoE(nnx.Module):
   ) -> tuple[jax.Array, Optional[jax.Array], Optional[jax.Array]]:
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
-    gate_logits, pre_bias_logits = self.gate(inputs)
+
+    use_te_router = getattr(cfg, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
+    if use_te_router:
+      te_router.check_te_router_available()
+      gate_logits, _ = self.gate(inputs, return_raw_logits=True)
+      pre_bias_logits = None
+    else:
+      gate_logits, pre_bias_logits = self.gate(inputs)
 
     w0_kernel = jnp.asarray(self.wi_0[...], self.dtype)
     w1_kernel = jnp.asarray(self.wi_1[...], self.dtype)
@@ -2532,7 +2617,7 @@ class RoutedMoE(nnx.Module):
             wo_bias,
         )
       output, lb_loss, bias_updates = self.sparse_matmul(
-          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias
+          inputs, gate_logits, pre_bias_logits, w0_kernel, w1_kernel, wo_kernel, w0_bias, w1_bias, wo_bias,
       )
     else:
       output, lb_loss, bias_updates = self.dense_matmul(

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -658,17 +658,15 @@ class RoutedMoE(nnx.Module):
         intermediate_layer = jnp.multiply(layer_act, layer_w1)
       return intermediate_layer.astype(self.dtype)
 
-  def _mt_permute(self, inputs, weights, selected_experts, use_custom_sort_vjp=True, roll_to_expert_id=None):
-    """Pure MaxText token permutation — no routing logic.
-
-    Sorts tokens by expert assignment using argsort. All routing decisions
-    (which experts, what weights) must be made before calling this method.
+  def _mt_permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None, roll_to_expert_id=None):
+    """MaxText routing + permutation: route via get_topk then sort tokens by expert.
 
     Args:
       inputs: Input tensor of shape [batch, seq, hidden].
-      weights: Routing weights [batch, seq, num_experts_per_tok].
-      selected_experts: Top-k expert indices [batch, seq, num_experts_per_tok].
+      gate_logits: Router logits of shape [batch, seq, num_experts].
+      pre_bias_logits: Pre-bias logits for DeepSeek models, or None.
       use_custom_sort_vjp: Whether to use custom sort VJP.
+      rngs: Random number generators for dropout (if any).
       roll_to_expert_id: Expert ID offset for ring-of-experts.
 
     Returns:
@@ -678,10 +676,25 @@ class RoutedMoE(nnx.Module):
         - weights: Routing weights (passed through for unpermute).
         - group_size: Token counts per expert [num_experts].
         - sorted_experts: Expert ID for each sorted token position.
+        - lb_loss: Scalar load balance loss (or None).
+        - bias_updates: Bias update direction [num_experts] (or None).
     """
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
+
+    weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
+
+    lb_loss = None
+    if self.config.load_balance_loss_weight > 0.0:
+      softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
+      lb_loss = self.load_balance_loss(selected_experts, softmax_probs)
+
+    bias_updates = None
+    if self.should_update_load_balance():
+      bias_updates = calculate_load_balance_updates(
+          selected_experts, self.config.num_experts, self.config.routed_bias_update_rate
+      )
 
     if self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4:
       router_scores = jax.nn.sigmoid(weights.astype(jnp.float32))
@@ -708,39 +721,104 @@ class RoutedMoE(nnx.Module):
         weights,
         group_size,
         sorted_experts,
+        lb_loss,
+        bias_updates,
     )
 
   def _te_permute(
       self,
       inputs: jax.Array,
-      routing_map: jax.Array,
-      dense_probs: jax.Array,
-  ) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array, Optional[jax.Array]]:
-    """Pure TE token dispatch — no routing logic.
+      gate_logits: jax.Array,
+      gate_expert_bias: Optional[jax.Array],
+      rngs=None,
+      roll_to_expert_id=None,
+  ) -> Tuple[jax.Array, jax.Array, jax.Array, Optional[jax.Array], Optional[jax.Array], jax.Array, Optional[jax.Array]]:
+    """TE routing + permutation: fused router then TE token dispatch.
 
-    Rearranges tokens by expert using TransformerEngine's optimized kernels.
-    All routing decisions (which experts, what weights) must be made before
-    calling this method.
+    Combines TE's fused router (score_function + top-k + bias + scaling)
+    with TE's optimized permutation kernels into a single step.
+
+    The main routing kernel and aux scoring kernel are logically independent
+    (both read only from raw_logits_2d with no data dependency between them),
+    so XLA can overlap their GPU execution automatically.
 
     Args:
-      inputs: Input tensor of shape [batch, seq, hidden] or [num_tokens, hidden].
-      routing_map: Boolean routing mask [num_tokens, num_experts].
-      dense_probs: Dense routing probs [num_tokens, num_experts].
+      inputs: Input tensor of shape [batch, seq, hidden].
+      gate_logits: Raw GEMM logits [batch, seq, num_experts] (no score_func/bias).
+      gate_expert_bias: Expert bias [num_experts] or empty array [0].
+      rngs: Random number generators (unused, kept for signature compatibility).
+      roll_to_expert_id: Expert ID offset for ring-of-experts.
 
     Returns:
       Tuple of:
         - permuted_outputs: Tokens grouped by expert [num_out_tokens, hidden].
         - row_id_map: Mapping for unpermute phase.
         - tokens_per_expert: Token counts per expert [num_experts].
-        - dense_probs: Dense routing probs (passed through for unpermute).
+        - lb_loss: Scalar load balance loss (or None).
+        - bias_updates: Bias update direction [num_experts] (or None).
+        - dense_probs: Dense routing probs [num_tokens, num_experts] for combine.
         - pad_offsets: Padding offsets per expert (or None).
     """
+    te_router.check_te_router_available()
     te_permutation.check_te_permutation_available()
 
     hidden_size = inputs.shape[-1]
-    num_tokens = routing_map.shape[0]
+    num_tokens = inputs.shape[0] * inputs.shape[1]
     num_out_tokens = num_tokens * self.num_experts_per_tok
 
+    # --- TE Router ---
+    raw_logits_2d = gate_logits.reshape(num_tokens, -1)
+
+    router_dtype = jnp.float32 if self.config.logits_dot_in_fp32 else self.dtype
+    raw_logits_2d = raw_logits_2d.astype(router_dtype)
+    expert_bias_for_te = None
+    if gate_expert_bias is not None and gate_expert_bias.size > 0:
+      expert_bias_for_te = gate_expert_bias.astype(router_dtype)
+
+    sparse_probs, routing_map = te_router.te_fused_topk(
+        raw_logits_2d,
+        topk=self.num_experts_per_tok,
+        score_function=self.config.routed_score_func,
+        use_pre_softmax=False,
+        num_groups=self.config.n_routing_groups,
+        group_topk=self.config.topk_routing_group,
+        scaling_factor=self.config.routed_scaling_factor,
+        expert_bias=expert_bias_for_te,
+    )
+
+    sparse_probs = sparse_probs.astype(self.dtype)
+
+    aux_scores, aux_routing_map = None, None
+    if self.config.load_balance_loss_weight > 0.0:
+      aux_scores, aux_routing_map = te_router.te_compute_aux_scores(
+          raw_logits_2d,
+          topk=self.num_experts_per_tok,
+          score_function=self.config.routed_score_func,
+      )
+
+    lb_loss = None
+    if self.config.load_balance_loss_weight > 0.0:
+      aux_tokens_per_expert = jnp.sum(aux_routing_map.astype(jnp.int32), axis=0)
+      lb_loss = te_router.te_aux_loss(
+          aux_scores, aux_tokens_per_expert,
+          topk=self.num_experts_per_tok,
+          coeff=self.config.load_balance_loss_weight,
+      )
+      aux_scores = aux_scores.astype(self.dtype)
+
+    bias_updates = None
+    if self.should_update_load_balance():
+      main_tokens_per_expert = jnp.sum(routing_map.astype(jnp.int32), axis=0)
+      total_assignments = num_tokens * self.num_experts_per_tok
+      average_load = total_assignments / self.num_experts
+      direction = jnp.sign(average_load - main_tokens_per_expert)
+      bias_updates = direction * self.config.routed_bias_update_rate
+
+    if roll_to_expert_id is not None:
+      routing_map = jnp.roll(routing_map, -roll_to_expert_id, axis=-1)
+      sparse_probs = jnp.roll(sparse_probs, -roll_to_expert_id, axis=-1)
+
+    # --- TE Permutation ---
     align_size = self.config.te_permutation_align_size
     if align_size == 0:
       align_size = None
@@ -749,11 +827,11 @@ class RoutedMoE(nnx.Module):
         inputs.reshape(-1, hidden_size),
         routing_map,
         num_out_tokens=num_out_tokens,
-        probs=dense_probs,
+        probs=sparse_probs,
         align_size=align_size,
     )
 
-    return permuted_outputs, row_id_map, tokens_per_expert, dense_probs, pad_offsets
+    return permuted_outputs, row_id_map, tokens_per_expert, lb_loss, bias_updates, sparse_probs, pad_offsets
 
   def _te_unpermute(
       self,
@@ -846,182 +924,38 @@ class RoutedMoE(nnx.Module):
       )
     return output.reshape(batch_size, sequence_length, -1).astype(self.dtype)
 
-  def _te_route(self, gate_logits, gate_expert_bias, num_tokens, roll_to_expert_id=None):
-    """TE router: fused score_function + top-k + bias + scaling.
-
-    Wraps all TE routing logic including the fused top-k kernel,
-    auxiliary loss computation, and bias updates.
-
-    The main routing kernel and aux scoring kernel are logically independent
-    (both read only from raw_logits_2d with no data dependency between them),
-    so XLA can overlap their GPU execution automatically.
-
-    Args:
-      gate_logits: Raw GEMM logits [batch, seq, num_experts] (no score_func/bias).
-      gate_expert_bias: Expert bias [num_experts] or empty array [0].
-      num_tokens: Total number of tokens (batch * seq).
-      roll_to_expert_id: Expert ID offset for ring-of-experts.
-
-    Returns:
-      routing_map: Boolean routing mask [num_tokens, num_experts].
-      dense_probs: Sparse probs as dense [num_tokens, num_experts] for TE combine.
-      lb_loss: Scalar load balance loss or None.
-      bias_updates: Bias update direction [num_experts] or None.
-    """
-    te_router.check_te_router_available()
-
-    raw_logits_2d = gate_logits.reshape(num_tokens, -1)
-
-    router_dtype = jnp.float32 if self.config.logits_dot_in_fp32 else self.dtype
-    raw_logits_2d = raw_logits_2d.astype(router_dtype)
-    expert_bias_for_te = None
-    if gate_expert_bias is not None and gate_expert_bias.size > 0:
-      expert_bias_for_te = gate_expert_bias.astype(router_dtype)
-
-    sparse_probs, routing_map = te_router.te_fused_topk(
-        raw_logits_2d,
-        topk=self.num_experts_per_tok,
-        score_function=self.config.routed_score_func,
-        use_pre_softmax=False,
-        num_groups=self.config.n_routing_groups,
-        group_topk=self.config.topk_routing_group,
-        scaling_factor=self.config.routed_scaling_factor,
-        expert_bias=expert_bias_for_te,
-    )
-
-    sparse_probs = sparse_probs.astype(self.dtype)
-
-    # Aux scoring: score_func -> top-k (clean — no bias/groups/scaling)
-    aux_scores, aux_routing_map = None, None
-    if self.config.load_balance_loss_weight > 0.0:
-      aux_scores, aux_routing_map = te_router.te_compute_aux_scores(
-          raw_logits_2d,
-          topk=self.num_experts_per_tok,
-          score_function=self.config.routed_score_func,
-      )
-
-    # ---- Derive outputs from kernel results ----
-    # Aux loss uses the clean aux_routing_map (no bias influence) for
-    # tokens_per_expert, keeping the entire loss path bias-free.
-    lb_loss = None
-    if self.config.load_balance_loss_weight > 0.0:
-      aux_tokens_per_expert = jnp.sum(aux_routing_map.astype(jnp.int32), axis=0)
-      lb_loss = te_router.te_aux_loss(
-          aux_scores, aux_tokens_per_expert,
-          topk=self.num_experts_per_tok,
-          coeff=self.config.load_balance_loss_weight,
-      )
-      aux_scores = aux_scores.astype(self.dtype)
-
-    # Bias updates use the main routing_map (actual load after bias).
-    bias_updates = None
-    if self.should_update_load_balance():
-      main_tokens_per_expert = jnp.sum(routing_map.astype(jnp.int32), axis=0)
-      total_assignments = num_tokens * self.num_experts_per_tok
-      average_load = total_assignments / self.num_experts
-      direction = jnp.sign(average_load - main_tokens_per_expert)
-      bias_updates = direction * self.config.routed_bias_update_rate
-
-    # Roll for ring-of-experts
-    if roll_to_expert_id is not None:
-      routing_map = jnp.roll(routing_map, -roll_to_expert_id, axis=-1)
-      sparse_probs = jnp.roll(sparse_probs, -roll_to_expert_id, axis=-1)
-
-    return routing_map, sparse_probs, lb_loss, bias_updates
-
   def permute(self, inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp=True, rngs=None,
               roll_to_expert_id=None, gate_expert_bias=None):
-    """Permute tokens to group by expert.
-
-    Routing and permutation are fully decoupled:
-
-    Step 1 — Routing (top level, independent of permutation):
-      - TE router: _te_route() → (routing_map, dense_probs, lb_loss, bias_updates)
-      - MT router: get_topk() → (weights, top_k_indices) + lb_loss + bias_updates
-
-    Step 2 — Permutation (pure token rearrangement):
-      - TE permute: _te_permute(inputs, routing_map, dense_probs)
-      - MT permute: _mt_permute(inputs, weights, top_k_indices, ...)
+    """Permute tokens to group by expert. Dispatches to TE or MT implementation.
 
     Returns:
-      Tuple of (x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates):
-        - x: Permuted tokens [num_out_tokens, hidden].
-        - perm_state: PermState carrying implementation-specific state for unpermute.
-        - group_sizes: Token counts per expert [num_experts].
-        - selected_experts: Expert ID for each token position [num_out_tokens].
-        - lb_loss: Scalar load balance loss (or None).
-        - bias_updates: Bias update direction [num_experts] (or None).
+      Tuple of (x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates).
+      - x: Permuted tokens [num_out_tokens, hidden].
+      - perm_state: PermState carrying implementation-specific state for unpermute.
+      - group_sizes: Token counts per expert [num_experts].
+      - selected_experts: Expert ID for each token position [num_out_tokens].
+      - lb_loss: Load balance loss (or None).
+      - bias_updates: Bias updates (or None).
     """
-    use_te_perm = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE
-    use_te_rtr = getattr(self.config, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
-    perm_state = PermState(use_te_perm)
+    use_te = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    perm_state = PermState(use_te)
 
-    num_tokens = inputs.shape[0] * inputs.shape[1]
-
-    # =========================================================================
-    # Step 1: Routing — produces routing decisions, lb_loss, bias_updates
-    # =========================================================================
-    if use_te_rtr:
-      if not use_te_perm:
-        raise ValueError(
-            "te_router_impl=True requires te_permutation_impl=True. "
-            "The TE router outputs (sparse_probs, routing_map) are only compatible "
-            "with TE permutation."
-        )
-
-      routing_map, dense_probs, lb_loss, bias_updates = self._te_route(
-          gate_logits, gate_expert_bias, num_tokens, roll_to_expert_id,
-      )
-      weights = None
-      top_k_indices = None
-
-    else:
-      # --- MT Router (get_topk) ---
-      weights, top_k_indices = self.get_topk(gate_logits, pre_bias_logits, rngs)
-
-      lb_loss = None
-      if self.config.load_balance_loss_weight > 0.0:
-        softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
-        lb_loss = self.load_balance_loss(top_k_indices, softmax_probs)
-
-      bias_updates = None
-      if self.should_update_load_balance():
-        bias_updates = calculate_load_balance_updates(
-            top_k_indices, self.config.num_experts, self.config.routed_bias_update_rate
-        )
-
-      routing_map = None
-      dense_probs = None
-
-    # =========================================================================
-    # Step 2: Permutation — pure token rearrangement
-    # =========================================================================
-    if use_te_perm:
-      # Convert MT router outputs to TE format if needed
-      if routing_map is None:
-        if roll_to_expert_id is not None:
-          top_k_indices = (top_k_indices - roll_to_expert_id) % self.num_experts
-        routing_map = te_permutation.create_routing_map_from_indices(
-            top_k_indices, self.num_experts
-        )
-        dense_probs = te_permutation.create_dense_probs_from_topk(
-            weights, top_k_indices, self.num_experts
-        )
-
-      x, perm_state.row_id_map, group_sizes, perm_state.dense_probs, perm_state.pad_offsets = (
-          self._te_permute(inputs, routing_map, dense_probs)
+    if use_te:
+      (x, perm_state.row_id_map, group_sizes, lb_loss, bias_updates,
+       perm_state.dense_probs, perm_state.pad_offsets) = self._te_permute(
+          inputs, gate_logits, gate_expert_bias, rngs, roll_to_expert_id,
       )
 
       expert_indices = jnp.arange(self.num_experts)
       selected_experts = jnp.repeat(
           expert_indices, repeats=group_sizes, total_repeat_length=x.shape[0],
       )
-      perm_state.weights = weights
+      perm_state.weights = None
 
     else:
-      # MT permutation (MT router only — TE router requires TE perm)
-      x, perm_state.sorted_selected_experts, perm_state.weights, group_sizes, selected_experts = (
-          self._mt_permute(inputs, weights, top_k_indices, use_custom_sort_vjp, roll_to_expert_id)
+      (x, perm_state.sorted_selected_experts, perm_state.weights, group_sizes,
+       selected_experts, lb_loss, bias_updates) = self._mt_permute(
+          inputs, gate_logits, pre_bias_logits, use_custom_sort_vjp, rngs, roll_to_expert_id,
       )
 
     return x, perm_state, group_sizes, selected_experts, lb_loss, bias_updates
@@ -1449,10 +1383,10 @@ class RoutedMoE(nnx.Module):
   ):
     """Perform sparse matrix multiplication of inputs and Experts."""
 
-    # Extract gate expert bias internally when TE router is active.
+    # Extract gate expert bias internally when TE path is active.
     # This avoids exposing gate_expert_bias in the public API.
-    use_te_rtr = getattr(self.config, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
-    if use_te_rtr and hasattr(self, 'gate') and self.gate.use_bias:
+    use_te = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    if use_te and hasattr(self, 'gate') and self.gate.use_bias:
       gate_expert_bias = jnp.asarray(self.gate.bias[...], self.dtype)
     else:
       gate_expert_bias = jnp.empty((0,), dtype=self.dtype)
@@ -1714,7 +1648,7 @@ class RoutedMoE(nnx.Module):
           if is_batch_sharded_by_expert:
             # Compute per-expert token counts from all shards
             perm_state.all_shards_tokens_per_expert = jax.lax.all_gather(
-                group_sizes[None, :], axis_name=expert_axis_name, axis=0, tiled=True
+                group_sizes[None, :], axis_name=self._expert_parallelism_name, axis=0, tiled=True
             )
             input_offsets, send_sizes, output_offsets, recv_sizes = (
                 te_permutation.compute_ragged_all_to_all_params(
@@ -2593,9 +2527,8 @@ class RoutedMoE(nnx.Module):
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
 
-    use_te_router = getattr(cfg, "te_router_impl", False) and te_router.TE_ROUTER_AVAILABLE
-    if use_te_router:
-      te_router.check_te_router_available()
+    use_te = getattr(cfg, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    if use_te:
       gate_logits, _ = self.gate(inputs, return_raw_logits=True)
       pre_bias_logits = None
     else:

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -817,7 +817,7 @@ class RoutedMoE(nnx.Module):
       - lb_loss: Load balance loss (or None).
       - bias_updates: Bias updates (or None).
     """
-    use_te = getattr(self.config, "te_router_and_permutation_impl", False)
+    use_te = self.config.te_router_and_permutation_impl
     perm_state = PermState(use_te)
 
     if use_te:
@@ -1265,7 +1265,7 @@ class RoutedMoE(nnx.Module):
 
     # Extract gate expert bias internally when TE path is active.
     # This avoids exposing gate_expert_bias in the public API.
-    use_te = getattr(self.config, "te_router_and_permutation_impl", False)
+    use_te = self.config.te_router_and_permutation_impl
     if use_te and hasattr(self, 'gate') and self.gate.use_bias:
       gate_expert_bias = jnp.asarray(self.gate.bias[...], self.dtype)
     else:
@@ -2407,7 +2407,7 @@ class RoutedMoE(nnx.Module):
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
 
-    use_te = getattr(cfg, "te_router_and_permutation_impl", False)
+    use_te = cfg.te_router_and_permutation_impl
     if use_te:
       gate_logits, _ = self.gate(inputs, return_raw_logits=True)
       pre_bias_logits = None

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -679,6 +679,7 @@ class RoutedMoE(nnx.Module):
         - lb_loss: Scalar load balance loss (or None).
         - bias_updates: Bias update direction [num_experts] (or None).
     """
+    # reshape inputs (batch, sequence, emb) to (batch * sequence, emb)
     inputs_shape = inputs.shape
     bsz_times_seq_len = inputs_shape[0] * inputs_shape[1]
     inputs_2d = jnp.reshape(inputs, (bsz_times_seq_len, inputs_shape[2]))
@@ -697,18 +698,22 @@ class RoutedMoE(nnx.Module):
       )
 
     if self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4:
-      router_scores = jax.nn.sigmoid(weights.astype(jnp.float32))
+      # weights will be of shape (batch_size, seq_len, num_experts_per_tok)
+      router_scores = jax.nn.sigmoid(weights.astype(jnp.float32))  # weights are top_k_weights here
+      # Squeeze router_scores to (batch_size * seq_len, num_experts_per_tok)
       inputs_2d = inputs_2d * router_scores.reshape(bsz_times_seq_len, -1)
 
     flatten_selected_experts = jnp.ravel(selected_experts)
     if roll_to_expert_id is not None:
       flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
     sorted_selected_experts = jnp.argsort(flatten_selected_experts)
+    # sort inputs for number of selected experts
     replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
     sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
         self.dtype
     )
     group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
+    # Return the experts for each sorted input.
     expert_indices = jnp.arange(self.num_experts)
     sorted_experts = jnp.repeat(
         expert_indices,
@@ -725,167 +730,42 @@ class RoutedMoE(nnx.Module):
         bias_updates,
     )
 
-  def _te_permute(
-      self,
-      inputs: jax.Array,
-      gate_logits: jax.Array,
-      gate_expert_bias: Optional[jax.Array],
-      rngs=None,
-      roll_to_expert_id=None,
-  ) -> Tuple[jax.Array, jax.Array, jax.Array, Optional[jax.Array], Optional[jax.Array], jax.Array, Optional[jax.Array]]:
-    """TE routing + permutation: fused router then TE token dispatch.
-
-    Combines TE's fused router (score_function + top-k + bias + scaling)
-    with TE's optimized permutation kernels into a single step.
-
-    The main routing kernel and aux scoring kernel are logically independent
-    (both read only from raw_logits_2d with no data dependency between them),
-    so XLA can overlap their GPU execution automatically.
-
-    Args:
-      inputs: Input tensor of shape [batch, seq, hidden].
-      gate_logits: Raw GEMM logits [batch, seq, num_experts] (no score_func/bias).
-      gate_expert_bias: Expert bias [num_experts] or empty array [0].
-      rngs: Random number generators (unused, kept for signature compatibility).
-      roll_to_expert_id: Expert ID offset for ring-of-experts.
-
-    Returns:
-      Tuple of:
-        - permuted_outputs: Tokens grouped by expert [num_out_tokens, hidden].
-        - row_id_map: Mapping for unpermute phase.
-        - tokens_per_expert: Token counts per expert [num_experts].
-        - lb_loss: Scalar load balance loss (or None).
-        - bias_updates: Bias update direction [num_experts] (or None).
-        - dense_probs: Dense routing probs [num_tokens, num_experts] for combine.
-        - pad_offsets: Padding offsets per expert (or None).
-    """
-    te_router.check_te_router_available()
-    te_permutation.check_te_permutation_available()
-
-    hidden_size = inputs.shape[-1]
-    num_tokens = inputs.shape[0] * inputs.shape[1]
-    num_out_tokens = num_tokens * self.num_experts_per_tok
-
-    # --- TE Router ---
-    raw_logits_2d = gate_logits.reshape(num_tokens, -1)
-
-    router_dtype = jnp.float32 if self.config.logits_dot_in_fp32 else self.dtype
-    raw_logits_2d = raw_logits_2d.astype(router_dtype)
-    expert_bias_for_te = None
-    if gate_expert_bias is not None and gate_expert_bias.size > 0:
-      expert_bias_for_te = gate_expert_bias.astype(router_dtype)
-
-    sparse_probs, routing_map = te_router.te_fused_topk(
-        raw_logits_2d,
-        topk=self.num_experts_per_tok,
-        score_function=self.config.routed_score_func,
-        use_pre_softmax=False,
-        num_groups=self.config.n_routing_groups,
-        group_topk=self.config.topk_routing_group,
-        scaling_factor=self.config.routed_scaling_factor,
-        expert_bias=expert_bias_for_te,
+  def _te_permute(self, inputs, gate_logits, gate_expert_bias, rngs=None, roll_to_expert_id=None):
+    """TE routing + permutation. Delegates to te_permutation.te_permute()."""
+    return te_permutation.te_permute(
+        inputs,
+        gate_logits,
+        gate_expert_bias,
+        num_experts=self.num_experts,
+        num_experts_per_tok=self.num_experts_per_tok,
+        dtype=self.dtype,
+        logits_dot_in_fp32=self.config.logits_dot_in_fp32,
+        routed_score_func=self.config.routed_score_func,
+        n_routing_groups=self.config.n_routing_groups,
+        topk_routing_group=self.config.topk_routing_group,
+        routed_scaling_factor=self.config.routed_scaling_factor,
+        load_balance_loss_weight=self.config.load_balance_loss_weight,
+        should_update_load_balance=self.should_update_load_balance(),
+        routed_bias_update_rate=self.config.routed_bias_update_rate,
+        te_permutation_align_size=self.config.te_permutation_align_size,
+        roll_to_expert_id=roll_to_expert_id,
     )
-
-    sparse_probs = sparse_probs.astype(self.dtype)
-
-    aux_scores, aux_routing_map = None, None
-    if self.config.load_balance_loss_weight > 0.0:
-      aux_scores, aux_routing_map = te_router.te_compute_aux_scores(
-          raw_logits_2d,
-          topk=self.num_experts_per_tok,
-          score_function=self.config.routed_score_func,
-      )
-
-    lb_loss = None
-    if self.config.load_balance_loss_weight > 0.0:
-      aux_tokens_per_expert = jnp.sum(aux_routing_map.astype(jnp.int32), axis=0)
-      lb_loss = te_router.te_aux_loss(
-          aux_scores, aux_tokens_per_expert,
-          topk=self.num_experts_per_tok,
-          coeff=self.config.load_balance_loss_weight,
-      )
-      aux_scores = aux_scores.astype(self.dtype)
-
-    bias_updates = None
-    if self.should_update_load_balance():
-      main_tokens_per_expert = jnp.sum(routing_map.astype(jnp.int32), axis=0)
-      total_assignments = num_tokens * self.num_experts_per_tok
-      average_load = total_assignments / self.num_experts
-      direction = jnp.sign(average_load - main_tokens_per_expert)
-      bias_updates = direction * self.config.routed_bias_update_rate
-
-    if roll_to_expert_id is not None:
-      routing_map = jnp.roll(routing_map, -roll_to_expert_id, axis=-1)
-      sparse_probs = jnp.roll(sparse_probs, -roll_to_expert_id, axis=-1)
-
-    # --- TE Permutation ---
-    align_size = self.config.te_permutation_align_size
-    if align_size == 0:
-      align_size = None
-
-    permuted_outputs, _permuted_probs, row_id_map, pad_offsets, tokens_per_expert = te_permutation.te_token_dispatch(
-        inputs.reshape(-1, hidden_size),
-        routing_map,
-        num_out_tokens=num_out_tokens,
-        probs=sparse_probs,
-        align_size=align_size,
-    )
-
-    return permuted_outputs, row_id_map, tokens_per_expert, lb_loss, bias_updates, sparse_probs, pad_offsets
 
   def _te_unpermute(
-      self,
-      expert_outputs: jax.Array,
-      row_id_map: jax.Array,
-      batch_size: int,
-      sequence_length: int,
-      dense_probs: Optional[jax.Array] = None,
-      pad_offsets: Optional[jax.Array] = None,
-  ) -> jax.Array:
-    """Unpermute expert outputs using TransformerEngine kernels.
-
-    Args:
-      expert_outputs: Output from grouped GEMM [num_out_tokens, hidden].
-      row_id_map: Row ID map from te_permute.
-      batch_size: Original batch size.
-      sequence_length: Original sequence length.
-      dense_probs: Dense routing probs [num_tokens, num_experts] from te_permute.
-                   Used as merging_probs for weighted combination.
-                   Already softmaxed over top-k experts in get_topk().
-      pad_offsets: Padding offsets per expert from te_permute (for unpadding).
-
-    Returns:
-      Combined output tensor [batch, seq, hidden].
-
-    Note on probs:
-      TE's token_combine directly multiplies each expert's contribution by
-      merging_probs[token_id, expert_id]. Since dense_probs is already
-      normalized (softmax over top-k in get_topk), no further processing needed.
-      For LLAMA4, we pass None (uses weight of 1 for each expert).
-    """
-    te_permutation.check_te_permutation_available()
-
-    hidden_size = expert_outputs.shape[-1]
-
-    # Prepare merging probabilities for weighted combination
-    # dense_probs is precomputed in te_permute() to avoid redundant computation
-    merging_probs = None
-    if self.config.decoder_block != ctypes.DecoderBlockType.LLAMA4:
-      merging_probs = dense_probs
-      # For LLAMA4, we don't use weighted combination (implicit weights of 1)
-
-    # Call TE token combine with proper merging probs and padding offsets
-    output = te_permutation.te_token_combine(
+      self, expert_outputs, row_id_map, batch_size, sequence_length,
+      dense_probs=None, pad_offsets=None,
+  ):
+    """Unpermute expert outputs. Delegates to te_permutation.te_unpermute()."""
+    return te_permutation.te_unpermute(
         expert_outputs,
         row_id_map,
-        merging_probs=merging_probs,
+        batch_size,
+        sequence_length,
+        dtype=self.dtype,
+        is_llama4=(self.config.decoder_block == ctypes.DecoderBlockType.LLAMA4),
+        dense_probs=dense_probs,
         pad_offsets=pad_offsets,
     )
-
-    # Reshape back to [batch, seq, hidden]
-    output = output.reshape(batch_size, sequence_length, hidden_size)
-
-    return output.astype(self.dtype)
 
   def _mt_unpermute(
       self,
@@ -937,7 +817,7 @@ class RoutedMoE(nnx.Module):
       - lb_loss: Load balance loss (or None).
       - bias_updates: Bias updates (or None).
     """
-    use_te = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    use_te = getattr(self.config, "te_router_and_permutation_impl", False)
     perm_state = PermState(use_te)
 
     if use_te:
@@ -1385,7 +1265,7 @@ class RoutedMoE(nnx.Module):
 
     # Extract gate expert bias internally when TE path is active.
     # This avoids exposing gate_expert_bias in the public API.
-    use_te = getattr(self.config, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    use_te = getattr(self.config, "te_router_and_permutation_impl", False)
     if use_te and hasattr(self, 'gate') and self.gate.use_bias:
       gate_expert_bias = jnp.asarray(self.gate.bias[...], self.dtype)
     else:
@@ -2527,7 +2407,7 @@ class RoutedMoE(nnx.Module):
     cfg = self.config
     inputs = inputs.astype(cfg.dtype)
 
-    use_te = getattr(cfg, "te_permutation_impl", False) and te_permutation.TE_PERMUTATION_AVAILABLE and te_router.TE_ROUTER_AVAILABLE
+    use_te = getattr(cfg, "te_router_and_permutation_impl", False)
     if use_te:
       gate_logits, _ = self.gate(inputs, return_raw_logits=True)
       pre_bias_logits = None

--- a/src/maxtext/layers/te_permutation.py
+++ b/src/maxtext/layers/te_permutation.py
@@ -18,14 +18,17 @@ This module provides wrapper functions for TransformerEngine's token dispatch
 and combine operations used in Mixture of Experts (MoE) models.
 
 The integration provides:
-- token_dispatch: Scatter tokens to their designated experts
-- token_combine: Gather tokens back from experts
+- te_permute: Route + dispatch tokens (delegates routing to te_router, then dispatches)
+- te_unpermute: Combine expert outputs back to original token order
+- te_token_dispatch: Low-level scatter tokens to their designated experts
+- te_token_combine: Low-level gather tokens back from experts
 - sort_chunks_by_index: Reorder chunks for expert parallelism
 - Efficient extraction of tokens_per_expert for ragged_all_to_all
 
 Key Design:
-- TE primitives use mask-based routing_map, so we convert MaxText's
-  index-based top_k_indices to a binary routing mask.
+- Routing logic (fused top-k, aux loss, bias updates) lives in te_router.py.
+- This module handles the permutation layer: dispatching tokens to experts
+  and combining them back, using TE's optimized kernels.
 - tokens_per_expert is computed efficiently inside the TE kernels,
   avoiding double iteration over the routing map.
 """
@@ -34,6 +37,8 @@ from typing import Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+
+from maxtext.layers import te_router
 
 # Import TransformerEngine permutation primitives
 try:
@@ -58,93 +63,6 @@ def check_te_permutation_available():
         "Please install TransformerEngine with JAX support: "
         "pip install transformer-engine[jax]"
     )
-
-
-def create_routing_map_from_indices(
-    top_k_indices: jnp.ndarray,
-    num_experts: int,
-) -> jnp.ndarray:
-  """Convert top-k expert indices to a binary routing mask.
-
-  The TE permutation primitives expect a routing_map (binary mask) of shape
-  [num_tokens, num_experts] where routing_map[i, j] = 1 means token i is
-  routed to expert j.
-
-  Args:
-    top_k_indices: Expert indices of shape [batch, seq, num_experts_per_tok]
-                   or [num_tokens, num_experts_per_tok].
-    num_experts: Total number of experts.
-
-  Returns:
-    routing_map: Binary mask of shape [num_tokens, num_experts].
-  """
-  # Flatten to 2D if needed: [num_tokens, num_experts_per_tok]
-  original_shape = top_k_indices.shape
-  if top_k_indices.ndim == 3:
-    num_tokens = original_shape[0] * original_shape[1]
-    top_k_indices = top_k_indices.reshape(num_tokens, -1)
-
-  # Create one-hot encoding for each selected expert
-  # Shape: [num_tokens, num_experts_per_tok, num_experts]
-  one_hot = jax.nn.one_hot(top_k_indices, num_classes=num_experts, dtype=jnp.int32)
-
-  # Sum across the top-k dimension to get binary mask
-  # Shape: [num_tokens, num_experts]
-  routing_map = jnp.sum(one_hot, axis=1)
-
-  return routing_map
-
-
-def create_dense_probs_from_topk(
-    top_k_weights: jnp.ndarray,
-    top_k_indices: jnp.ndarray,
-    num_experts: int,
-) -> jnp.ndarray:
-  """Convert top-k weights to dense probability tensor for TE.
-
-  TE's token_dispatch expects probs of shape [num_tokens, num_experts] where
-  probs[i, j] = routing probability for token i to expert j (0 if not routed).
-
-  Args:
-    top_k_weights: Top-k routing weights of shape [batch, seq, num_experts_per_tok]
-                   or [num_tokens, num_experts_per_tok]. These are the softmax
-                   probabilities for the selected experts.
-    top_k_indices: Expert indices of shape [batch, seq, num_experts_per_tok]
-                   or [num_tokens, num_experts_per_tok].
-    num_experts: Total number of experts.
-
-  Returns:
-    dense_probs: Dense probability tensor of shape [num_tokens, num_experts].
-                 Non-selected experts have probability 0.
-  """
-  # Flatten to 2D if needed
-  original_shape = top_k_indices.shape
-  if top_k_indices.ndim == 3:
-    num_tokens = original_shape[0] * original_shape[1]
-    top_k_indices = top_k_indices.reshape(num_tokens, -1)
-    top_k_weights = top_k_weights.reshape(num_tokens, -1)
-  else:
-    num_tokens = top_k_indices.shape[0]
-
-  num_experts_per_tok = top_k_indices.shape[-1]
-
-  # Create one-hot encoding for each selected expert
-  # Shape: [num_tokens, num_experts_per_tok, num_experts]
-  one_hot = jax.nn.one_hot(top_k_indices, num_classes=num_experts, dtype=top_k_weights.dtype)
-
-  # Scale one-hot by weights: multiply each expert's one-hot by its weight
-  # top_k_weights shape: [num_tokens, num_experts_per_tok]
-  # Expand for broadcasting: [num_tokens, num_experts_per_tok, 1]
-  weights_expanded = top_k_weights[:, :, None]
-
-  # Element-wise multiply: [num_tokens, num_experts_per_tok, num_experts]
-  weighted_one_hot = one_hot * weights_expanded
-
-  # Sum across top-k dimension to get dense probs
-  # Shape: [num_tokens, num_experts]
-  dense_probs = jnp.sum(weighted_one_hot, axis=1)
-
-  return dense_probs
 
 
 def te_token_dispatch(
@@ -418,3 +336,138 @@ def compute_reverse_ragged_all_to_all_params(
   ).squeeze(0)
 
   return input_offsets, send_sizes, output_offsets, recv_sizes
+
+
+def te_permute(
+    inputs: jnp.ndarray,
+    gate_logits: jnp.ndarray,
+    gate_expert_bias: Optional[jnp.ndarray],
+    num_experts: int,
+    num_experts_per_tok: int,
+    dtype: jnp.dtype,
+    logits_dot_in_fp32: bool,
+    routed_score_func: str,
+    n_routing_groups: int,
+    topk_routing_group: int,
+    routed_scaling_factor: float,
+    load_balance_loss_weight: float,
+    should_update_load_balance: bool,
+    routed_bias_update_rate: float,
+    te_permutation_align_size: int,
+    roll_to_expert_id: Optional[int] = None,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, Optional[jnp.ndarray],
+           Optional[jnp.ndarray], jnp.ndarray, Optional[jnp.ndarray]]:
+  """TE routing + permutation: fused router then TE token dispatch.
+
+  Delegates routing to te_router.te_route(), then dispatches tokens
+  to experts via te_token_dispatch().
+
+  Args:
+    inputs: Input tensor of shape [batch, seq, hidden].
+    gate_logits: Raw GEMM logits [batch, seq, num_experts] (no score_func/bias).
+    gate_expert_bias: Expert bias [num_experts] or empty array [0].
+    num_experts: Total number of experts.
+    num_experts_per_tok: Number of experts each token is routed to.
+    dtype: Compute dtype.
+    logits_dot_in_fp32: Whether to cast logits to float32 for routing.
+    routed_score_func: Score function name ("softmax", "sigmoid", or "").
+    n_routing_groups: Number of groups for grouped top-k routing.
+    topk_routing_group: Top-k at group level.
+    routed_scaling_factor: Scaling factor for output probabilities.
+    load_balance_loss_weight: Weight for load balance loss (0 disables).
+    should_update_load_balance: Whether to compute bias updates.
+    routed_bias_update_rate: Rate for bias updates.
+    te_permutation_align_size: Alignment size for padding (0 disables).
+    roll_to_expert_id: Expert ID offset for ring-of-experts.
+
+  Returns:
+    Tuple of:
+      - permuted_outputs: Tokens grouped by expert [num_out_tokens, hidden].
+      - row_id_map: Mapping for unpermute phase.
+      - tokens_per_expert: Token counts per expert [num_experts].
+      - lb_loss: Scalar load balance loss (or None).
+      - bias_updates: Bias update direction [num_experts] (or None).
+      - sparse_probs: Sparse routing probs [num_tokens, num_experts] for combine.
+      - pad_offsets: Padding offsets per expert (or None).
+  """
+  check_te_permutation_available()
+
+  sparse_probs, routing_map, lb_loss, bias_updates = te_router.te_route(
+      gate_logits,
+      gate_expert_bias,
+      num_experts=num_experts,
+      num_experts_per_tok=num_experts_per_tok,
+      dtype=dtype,
+      logits_dot_in_fp32=logits_dot_in_fp32,
+      routed_score_func=routed_score_func,
+      n_routing_groups=n_routing_groups,
+      topk_routing_group=topk_routing_group,
+      routed_scaling_factor=routed_scaling_factor,
+      load_balance_loss_weight=load_balance_loss_weight,
+      should_update_load_balance=should_update_load_balance,
+      routed_bias_update_rate=routed_bias_update_rate,
+      roll_to_expert_id=roll_to_expert_id,
+  )
+
+  hidden_size = inputs.shape[-1]
+  num_tokens = inputs.shape[0] * inputs.shape[1]
+  num_out_tokens = num_tokens * num_experts_per_tok
+
+  align_size = te_permutation_align_size
+  if align_size == 0:
+    align_size = None
+
+  permuted_outputs, _permuted_probs, row_id_map, pad_offsets, tokens_per_expert = (
+      te_token_dispatch(
+          inputs.reshape(-1, hidden_size),
+          routing_map,
+          num_out_tokens=num_out_tokens,
+          probs=sparse_probs,
+          align_size=align_size,
+      )
+  )
+
+  return (permuted_outputs, row_id_map, tokens_per_expert, lb_loss,
+          bias_updates, sparse_probs, pad_offsets)
+
+
+def te_unpermute(
+    expert_outputs: jnp.ndarray,
+    row_id_map: jnp.ndarray,
+    batch_size: int,
+    sequence_length: int,
+    dtype: jnp.dtype,
+    is_llama4: bool = False,
+    dense_probs: Optional[jnp.ndarray] = None,
+    pad_offsets: Optional[jnp.ndarray] = None,
+) -> jnp.ndarray:
+  """Unpermute expert outputs using TransformerEngine kernels.
+
+  Args:
+    expert_outputs: Output from grouped GEMM [num_out_tokens, hidden].
+    row_id_map: Row ID map from te_permute.
+    batch_size: Original batch size.
+    sequence_length: Original sequence length.
+    dtype: Output dtype.
+    is_llama4: If True, skip weighted combination (implicit weights of 1).
+    dense_probs: Dense routing probs [num_tokens, num_experts] from te_permute.
+                 Used as merging_probs for weighted combination.
+    pad_offsets: Padding offsets per expert from te_permute (for unpadding).
+
+  Returns:
+    Combined output tensor [batch, seq, hidden].
+  """
+  check_te_permutation_available()
+
+  merging_probs = None
+  if not is_llama4:
+    merging_probs = dense_probs
+
+  output = te_token_combine(
+      expert_outputs,
+      row_id_map,
+      merging_probs=merging_probs,
+      pad_offsets=pad_offsets,
+  )
+
+  return output.reshape(batch_size, sequence_length, -1).astype(dtype)

--- a/src/maxtext/layers/te_router.py
+++ b/src/maxtext/layers/te_router.py
@@ -1,0 +1,202 @@
+# Copyright 2023-2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TransformerEngine Router Integration for MaxText MoE.
+
+This module provides wrapper functions for TransformerEngine's fused MoE router
+operations used in Mixture of Experts (MoE) models.
+
+The TE router fuses score_function + top-k selection + expert bias + scaling
+into a single CUDA kernel with proper automatic differentiation support.
+
+The integration provides:
+- te_fused_topk: Fused score_function(logits) → [bias] → top-k → [post-softmax] → scale.
+  Returns (sparse_probs, routing_map) in the format expected by TE permutation.
+- te_compute_aux_scores: Clean score_function(logits) → top-k (no bias/groups/scaling).
+  Returns dense scores for aux loss computation.
+- te_aux_loss: Fused MoE auxiliary load-balancing loss computation.
+
+Key Design:
+- TE router takes raw GEMM logits (before any score function or bias) and handles
+  score_function (softmax/sigmoid), expert_bias, grouped top-k, use_pre_softmax,
+  and scaling_factor internally via fused CUDA kernels.
+- The output format (sparse_probs, routing_map) feeds directly into TE permutation's
+  token_dispatch without needing index-to-mask or weight-to-dense-probs conversion.
+"""
+
+from typing import Optional, Tuple
+
+import jax.numpy as jnp
+
+try:
+  from transformer_engine.jax.router import (
+      fused_topk_with_score_function,
+      fused_moe_aux_loss,
+      ScoreFunction,
+  )
+  TE_ROUTER_AVAILABLE = True
+except ImportError:
+  TE_ROUTER_AVAILABLE = False
+  fused_topk_with_score_function = None
+  fused_moe_aux_loss = None
+  ScoreFunction = None
+
+
+def check_te_router_available():
+  """Check if TransformerEngine router is available."""
+  if not TE_ROUTER_AVAILABLE:
+    raise ImportError(
+        "TransformerEngine router is not available. "
+        "Please install TransformerEngine with JAX support: "
+        "pip install transformer-engine[jax]"
+    )
+
+
+def get_te_score_function(score_func_str: str):
+  """Convert MaxText score function string to TE ScoreFunction enum.
+
+  Args:
+    score_func_str: Score function name from MaxText config
+      ("sigmoid", "softmax", or "" which defaults to softmax).
+
+  Returns:
+    TE ScoreFunction enum value.
+  """
+  check_te_router_available()
+  if score_func_str == "sigmoid":
+    return ScoreFunction.SIGMOID
+  return ScoreFunction.SOFTMAX
+
+
+def te_fused_topk(
+    logits: jnp.ndarray,
+    topk: int,
+    score_function: str = "",
+    use_pre_softmax: bool = False,
+    num_groups: int = -1,
+    group_topk: int = -1,
+    scaling_factor: float = 1.0,
+    expert_bias: Optional[jnp.ndarray] = None,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  """Fused top-k routing using TransformerEngine's CUDA kernel.
+
+  Pipeline: score_function(logits) → [optional bias] → top-k →
+            [optional post-softmax] → scale.
+
+  This is a plug-and-play alternative to MaxText's get_topk() method.
+  It takes raw GEMM logits and produces (sparse_probs, routing_map)
+  which can be fed directly to TE permutation's token_dispatch.
+
+  Args:
+    logits: Raw GEMM logits of shape [num_tokens, num_experts].
+      These should be the direct output of the gating linear layer,
+      before any score function (softmax/sigmoid) or bias is applied.
+    topk: Number of top experts to select per token.
+    score_function: Score function to apply to logits.
+      "softmax", "sigmoid", or "" (defaults to softmax).
+    use_pre_softmax: If True, apply softmax before top-k selection.
+      If False (default), apply softmax after top-k (post-softmax).
+      Only relevant when score_function is softmax.
+    num_groups: Number of groups for grouped top-k routing (e.g., DeepSeek).
+      <= 0 disables grouping (default).
+    group_topk: Top-k at group level for grouped routing.
+      <= 0 disables group-level selection (default).
+    scaling_factor: Scaling factor applied to output probabilities.
+    expert_bias: Expert bias of shape [num_experts].
+      Added to scores before top-k selection. Only used with sigmoid
+      score function (e.g., DeepSeek V3 loss-free load balancing).
+      Pass None if unused.
+
+  Returns:
+    sparse_probs: Sparse probability tensor of shape [num_tokens, num_experts].
+      Non-zero only at the top-k selected expert positions per token.
+    routing_map: Boolean mask of shape [num_tokens, num_experts].
+      True at selected expert positions.
+  """
+  check_te_router_available()
+
+  te_score_func = get_te_score_function(score_function)
+
+  sparse_probs, routing_map = fused_topk_with_score_function(
+      logits,
+      topk=topk,
+      use_pre_softmax=use_pre_softmax,
+      num_groups=num_groups,
+      group_topk=group_topk,
+      scaling_factor=scaling_factor,
+      score_function=te_score_func,
+      expert_bias=expert_bias,
+  )
+
+  return sparse_probs, routing_map
+
+
+def te_compute_aux_scores(
+    logits: jnp.ndarray,
+    topk: int,
+    score_function: str = "",
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  """Compute clean dense scores for auxiliary loss using TE fused kernel.
+
+  Runs score_function(logits) → top-k with no bias, groups, or scaling.
+  Returns dense scores (all expert positions non-zero) suitable for
+  computing the auxiliary load-balancing loss.
+
+  Args:
+    logits: Raw GEMM logits of shape [num_tokens, num_experts].
+    topk: Number of top experts to select per token.
+    score_function: Score function name ("softmax", "sigmoid", or "").
+
+  Returns:
+    aux_scores: Dense score tensor [num_tokens, num_experts].
+      All expert positions contain scores (not sparse).
+    routing_map: Boolean mask [num_tokens, num_experts].
+      True at selected expert positions (clean selection, no bias).
+  """
+  check_te_router_available()
+  te_score_func = get_te_score_function(score_function)
+
+  aux_scores, routing_map = fused_topk_with_score_function(
+      logits,
+      topk=topk,
+      compute_aux_scores=True,
+      score_function=te_score_func,
+  )
+
+  return aux_scores, routing_map
+
+
+def te_aux_loss(
+    probs: jnp.ndarray,
+    tokens_per_expert: jnp.ndarray,
+    topk: int,
+    coeff: float,
+) -> jnp.ndarray:
+  """Compute MoE auxiliary load-balancing loss using TE fused kernel.
+
+  loss = (E * coeff / (k * T^2)) * sum_i(sum_t(probs[t,i]) * tokens_per_expert[i])
+
+  where T = num_tokens, E = num_experts, k = topk.
+
+  Args:
+    probs: Score tensor from te_compute_aux_scores [num_tokens, num_experts].
+    tokens_per_expert: Token counts per expert [num_experts]. Integer tensor.
+    topk: Top-k value.
+    coeff: Loss coefficient (e.g., load_balance_loss_weight).
+
+  Returns:
+    Scalar loss value.
+  """
+  check_te_router_available()
+  return fused_moe_aux_loss(probs, tokens_per_expert, topk, coeff)

--- a/src/maxtext/layers/te_router.py
+++ b/src/maxtext/layers/te_router.py
@@ -21,6 +21,8 @@ The TE router fuses score_function + top-k selection + expert bias + scaling
 into a single CUDA kernel with proper automatic differentiation support.
 
 The integration provides:
+- te_route: Full routing pipeline — fused top-k, aux loss, and bias updates.
+  This is the main entry point called by te_permutation.te_permute().
 - te_fused_topk: Fused score_function(logits) → [bias] → top-k → [post-softmax] → scale.
   Returns (sparse_probs, routing_map) in the format expected by TE permutation.
 - te_compute_aux_scores: Clean score_function(logits) → top-k (no bias/groups/scaling).
@@ -200,3 +202,104 @@ def te_aux_loss(
   """
   check_te_router_available()
   return fused_moe_aux_loss(probs, tokens_per_expert, topk, coeff)
+
+
+def te_route(
+    gate_logits: jnp.ndarray,
+    gate_expert_bias: Optional[jnp.ndarray],
+    num_experts: int,
+    num_experts_per_tok: int,
+    dtype: jnp.dtype,
+    logits_dot_in_fp32: bool,
+    routed_score_func: str,
+    n_routing_groups: int,
+    topk_routing_group: int,
+    routed_scaling_factor: float,
+    load_balance_loss_weight: float,
+    should_update_load_balance: bool,
+    routed_bias_update_rate: float,
+    roll_to_expert_id: Optional[int] = None,
+) -> Tuple[jnp.ndarray, jnp.ndarray, Optional[jnp.ndarray], Optional[jnp.ndarray]]:
+  """Full TE routing pipeline: fused top-k, aux loss, and bias updates.
+
+  Runs TE's fused router kernel to produce routing decisions, then computes
+  the auxiliary load-balancing loss and bias updates if configured.
+
+  The main routing kernel and aux scoring kernel are logically independent
+  (both read only from raw_logits_2d with no data dependency between them),
+  so XLA can overlap their GPU execution automatically.
+
+  Args:
+    gate_logits: Raw GEMM logits [batch, seq, num_experts] (before score_func/bias).
+    gate_expert_bias: Expert bias [num_experts] or empty array [0].
+    num_experts: Total number of experts.
+    num_experts_per_tok: Number of experts each token is routed to.
+    dtype: Compute dtype.
+    logits_dot_in_fp32: Whether to cast logits to float32 for routing.
+    routed_score_func: Score function name ("softmax", "sigmoid", or "").
+    n_routing_groups: Number of groups for grouped top-k routing.
+    topk_routing_group: Top-k at group level.
+    routed_scaling_factor: Scaling factor for output probabilities.
+    load_balance_loss_weight: Weight for load balance loss (0 disables).
+    should_update_load_balance: Whether to compute bias updates.
+    routed_bias_update_rate: Rate for bias updates.
+    roll_to_expert_id: Expert ID offset for ring-of-experts.
+
+  Returns:
+    Tuple of:
+      - sparse_probs: Sparse routing probs [num_tokens, num_experts].
+      - routing_map: Boolean routing mask [num_tokens, num_experts].
+      - lb_loss: Scalar load balance loss (or None).
+      - bias_updates: Bias update direction [num_experts] (or None).
+  """
+  check_te_router_available()
+
+  num_tokens = gate_logits.shape[0] * gate_logits.shape[1]
+  raw_logits_2d = gate_logits.reshape(num_tokens, -1)
+
+  router_dtype = jnp.float32 if logits_dot_in_fp32 else dtype
+  raw_logits_2d = raw_logits_2d.astype(router_dtype)
+  expert_bias_for_te = None
+  if gate_expert_bias is not None and gate_expert_bias.size > 0:
+    expert_bias_for_te = gate_expert_bias.astype(router_dtype)
+
+  sparse_probs, routing_map = te_fused_topk(
+      raw_logits_2d,
+      topk=num_experts_per_tok,
+      score_function=routed_score_func,
+      use_pre_softmax=False,
+      num_groups=n_routing_groups,
+      group_topk=topk_routing_group,
+      scaling_factor=routed_scaling_factor,
+      expert_bias=expert_bias_for_te,
+  )
+
+  sparse_probs = sparse_probs.astype(dtype)
+
+  lb_loss = None
+  if load_balance_loss_weight > 0.0:
+    aux_scores, aux_routing_map = te_compute_aux_scores(
+        raw_logits_2d,
+        topk=num_experts_per_tok,
+        score_function=routed_score_func,
+    )
+    aux_tokens_per_expert = jnp.sum(aux_routing_map.astype(jnp.int32), axis=0)
+    lb_loss = te_aux_loss(
+        aux_scores, aux_tokens_per_expert,
+        topk=num_experts_per_tok,
+        coeff=load_balance_loss_weight,
+    )
+
+  bias_updates = None
+  if should_update_load_balance:
+    main_tokens_per_expert = jnp.sum(routing_map.astype(jnp.int32), axis=0)
+    total_assignments = num_tokens * num_experts_per_tok
+    average_load = total_assignments / num_experts
+    direction = jnp.sign(average_load - main_tokens_per_expert)
+    bias_updates = direction * routed_bias_update_rate
+
+  if roll_to_expert_id is not None:
+    routing_map = jnp.roll(routing_map, -roll_to_expert_id, axis=-1)
+    sparse_probs = jnp.roll(sparse_probs, -roll_to_expert_id, axis=-1)
+
+  return sparse_probs, routing_map, lb_loss, bias_updates


### PR DESCRIPTION
# Description
TE's router has a potential to be faster than the pure JAX router currently used in maxtext. Especially when coupled with TE's permutation (with `use_te_permutation` config), permutation will directly consume the output from router in the form of a binary routing map, without needing to adapt the output from a list of indices. 

More performance data can be uploaded later

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests
I compared the loss in 30 steps from training mixtral-8x7b.yaml (with only 4 layers) between MaxText's pure jax code path with the loss when using te_router and they are the same.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run end-to-end tests tests and provided workload links above if applicable.
- [ ] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
