### PR TITLE
[JAX] Fix block scaling init of GateLogit

### DIFF
--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -294,7 +294,8 @@ class GateLogit(nnx.Module):
       quant_dot_general = nnx_wrappers.ToNNX(dot_general_linen, rngs=rngs)
       self._quant_dot_general_name = f"{type(dot_general_linen).__name__}_0"
       setattr(self, self._quant_dot_general_name, quant_dot_general)
-      dummy_inputs = jnp.zeros((1, *self.in_features_shape), dtype=self.dtype)
+      block_size = getattr(quant, "get_block_size", lambda: 1)()  # needed for TE block scaling
+      dummy_inputs = jnp.zeros((block_size, *self.in_features_shape), dtype=self.dtype)
       self(dummy_inputs, _initializing=True)
     else:
       self._quant_dot_general_name = None


### PR DESCRIPTION
# Description

GateLogit in moe.py uses the quantizer's dot_general function for quantized non-grouped GEMMs, similar to linears.py for Dense layers. However, GateLogit was initializing with a placeholder input shape (1, dim) which fails for TE's block scaled quantization. This is a two-line change to carry over the same fix used in linears.py and use a block size helper function dependent on recipe.
