### PR TITLE
[TE] MaxText permute padding and alignment

### DIFF
--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -199,6 +199,7 @@ use_ring_of_experts: false # whether to use ring of experts for sparse matmul ex
 te_router_and_permutation_impl: false # whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine
 te_permutation_align_size: 128 # alignment size for TE permutation padding, set to 0 to disable padding
 te_use_gmm: false # whether to use the TE GMM implementation for MoE matmuls
+te_gmm_quantization: "" # quantization mode for TE GMM matmuls, must be specified when te_use_gmm is true.
 # tunable tiling dimensions used for mlp gmm
 # megablox/jax ragged dot - supports forward pass only (6 configs: `wi_tile_fwd...` and `wo_tile_fwd_...`)
 # tokamax ragged dot - supports all 18 configs

--- a/src/maxtext/configs/base.yml
+++ b/src/maxtext/configs/base.yml
@@ -197,7 +197,7 @@ use_random_routing: false # whether to use random routing for debug/test purpose
 use_custom_sort_vjp: true # whether to use a custom VJP sort for efficient backward pass processing in sparse matmul
 use_ring_of_experts: false # whether to use ring of experts for sparse matmul expert parallelism
 te_router_and_permutation_impl: false # whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine
-te_permutation_align_size: 128 # alignment size for TE permutation padding, set to 0 to disable padding
+moe_permutation_group_align_size: 128 # alignment size for MoE permutation group padding (MT and TE paths), set to 0 to disable
 te_use_gmm: false # whether to use the TE GMM implementation for MoE matmuls
 # tunable tiling dimensions used for mlp gmm
 # megablox/jax ragged dot - supports forward pass only (6 configs: `wi_tile_fwd...` and `wo_tile_fwd_...`)

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -654,9 +654,9 @@ class MoEGeneral(BaseModel):
       False,
       description="Whether to use TransformerEngine fused router and permutation kernels for MoE routing and token dispatch/combine.",
   )
-  te_permutation_align_size: int = Field(
+  moe_permutation_group_align_size: int = Field(
       128,
-      description="Alignment size for TE permutation padding. Set to 0 to disable padding.",
+      description="Alignment size for MoE permutation group padding (MT and TE paths). Set to 0 to disable.",
   )
   te_use_gmm: bool = Field(
       False,

--- a/src/maxtext/configs/types.py
+++ b/src/maxtext/configs/types.py
@@ -91,12 +91,20 @@ class QuantizationType(str, Enum):
   FP8_NANO_V2 = "fp8_nanoo"
   FP8_GPU = "fp8_gpu"
   FP8_FULL = "fp8_full"
+  TE_NO_QUANT = "te_no_quant"
   TE_FP8_DS = "te_fp8_delayedscaling"
   TE_FP8_CS = "te_fp8_currentscaling"
   TE_MXFP8 = "te_mxfp8"
   TE_NVFP4 = "te_nvfp4"
   TE_NVFP4_NO_RHT = "te_nvfp4_no_rht"
 
+
+class TEGroupedGemmQuantizationType(str, Enum):
+    """Supported quantization schemes for TE grouped GEMM in MoE layers."""
+
+    EMPTY = "" # Invalid when te_use_gmm is true, an explicit precision must be specified.
+    TE_NO_QUANT = "te_no_quant" # Default precision, e.g. BF16, without quantization
+    TE_MXFP8 = "te_mxfp8"
 
 class KvQuantAxis(str, Enum):
   """Axes to quantize over for the Key-Value cache."""
@@ -661,6 +669,10 @@ class MoEGeneral(BaseModel):
   te_use_gmm: bool = Field(
       False,
       description="Whether to use TransformerEngine Grouped GEMM kernels for matmuls in MoE layers.",
+  )
+  te_gmm_quantization: None | TEGroupedGemmQuantizationType = Field(
+      TEGroupedGemmQuantizationType.EMPTY,
+      description="Quantization mode for TE GMM matmuls, must be specified when te_use_gmm is true.",
   )
   use_random_routing: bool = Field(False, description="Whether to use random routing for debugging.")
   interleave_moe_layer_step: int = Field(1, description="Frequency of MoE layers, e.g., 2 means every 2nd layer is MoE.")
@@ -2542,6 +2554,10 @@ class MaxTextConfig(
         raise ValueError("Loss-free load balancing is only supported for the DeepSeek decoder block.")
       if self.te_router_and_permutation_impl and not self.sparse_matmul:
         raise ValueError("te_router_and_permutation_impl=True requires sparse_matmul=True.")
+      if self.te_use_gmm and not self.sparse_matmul:
+        raise ValueError("te_use_gmm=True requires sparse_matmul=True.")
+      if self.te_use_gmm and self.te_gmm_quantization == TEGroupedGemmQuantizationType.EMPTY:
+        raise ValueError("te_gmm_quantization must be specified when te_use_gmm is True.")
     if self.use_multimodal:
       valid_mm_models = (
           "gemma3-4b",

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1292,8 +1292,8 @@ class RoutedMoE(nnx.Module):
             assert not self.config.megablox and not self.config.use_tokamax_gmm, "TE GMM is only supported when Megablox and Tokamax GMM are disabled."
             assert self.config.quantization and self.config.quantization.startswith("te_"), "TE GMM currently requires TE quantization."
             # TODO(jberchtold): Adjust this based on TE GMM requirements per recipe
-            TE_GMM_ALIGN_REQUIREMENT = 128
-            assert self.config.te_router_and_permutation_impl and self.config.te_permutation_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
+            te_gmm_align_size_requirement = self.quant.get_gmm_align_size(self.config.te_gmm_quantization)
+            assert self.config.te_router_and_permutation_impl and self.config.te_permutation_align_size % te_gmm_align_size_requirement == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {te_gmm_align_size_requirement})."
             return self.quant.gmm(inputs, kernel, tiling, group_sizes, expert_assignments, self.config.te_gmm_quantization)
 
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1608,8 +1608,9 @@ class RoutedMoE(nnx.Module):
         # Filter down to the group sizes that apply to only the experts in the
         # current shard.
         group_sizes = group_sizes[:num_experts_per_shard]
-        mask = jnp.arange(x.shape[0]) < jnp.sum(group_sizes)
-        x = jnp.where(mask[:, None], x, 0)
+        if not use_te:
+          mask = jnp.arange(x.shape[0]) < jnp.sum(group_sizes)
+          x = jnp.where(mask[:, None], x, 0)
       else:
         # =======================================================================
         # Global Permutation (dispatches to TE or MT inside self.permute)

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -1294,7 +1294,7 @@ class RoutedMoE(nnx.Module):
             # TODO(jberchtold): Adjust this based on TE GMM requirements per recipe
             TE_GMM_ALIGN_REQUIREMENT = 128
             assert self.config.te_router_and_permutation_impl and self.config.te_permutation_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
-            return self.quant.gmm(inputs, kernel, tiling, group_sizes, expert_assignments)
+            return self.quant.gmm(inputs, kernel, tiling, group_sizes, expert_assignments, self.config.te_gmm_quantization)
 
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
       if self.config.using_pipeline_parallelism and self.config.pipeline_fsdp_ag_per_repeat:

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -699,6 +699,28 @@ class RoutedMoE(nnx.Module):
 
     weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
 
+    token_count_per_expert = jnp.bincount(selected_experts.ravel(), length=self.num_experts)
+    padding_tokens_required_per_expert = self.config.te_permutation_align_size - (token_count_per_expert % self.config.te_permutation_align_size)
+    # Build a static-size padding index buffer.
+    # Each expert i gets a slot of (align_size - 1) positions (worst-case padding).
+    # Within slot i: positions where offset < padding_tokens_required_per_expert[i]
+    # are assigned to expert i; the rest point to the last expert and will be ignored
+    # by the GEMM (they sort to the tail of the buffer).
+    # E.g. padding_tokens_required_per_expert=(1,3), align_size=8 → total=14:
+    #   [0, last, last, last, last, last, last,   # slot 0: 1 real, 6 overflow
+    #    1, 1, 1, last, last, last, last]          # slot 1: 3 real, 4 overflow
+    max_padding_per_expert = self.config.te_permutation_align_size - 1
+    total_padding_size = self.num_experts * max_padding_per_expert
+    positions = jnp.arange(total_padding_size)
+    expert_for_pos = positions // max_padding_per_expert
+    offset_in_slot = positions % max_padding_per_expert
+    padding_needed = padding_tokens_required_per_expert[expert_for_pos]
+    flatten_padding_selected_experts = jnp.where(
+        offset_in_slot < padding_needed,
+        expert_for_pos,
+        self.num_experts - 1,
+    )
+
     lb_loss = None
     if self.config.load_balance_loss_weight > 0.0:
       softmax_probs = jax.nn.softmax(gate_logits.astype(jnp.float32), axis=-1).astype(self.dtype)
@@ -717,11 +739,21 @@ class RoutedMoE(nnx.Module):
       inputs_2d = inputs_2d * router_scores.reshape(bsz_times_seq_len, -1)
 
     flatten_selected_experts = jnp.ravel(selected_experts)
+    flatten_selected_experts = jnp.concatenate([flatten_selected_experts, flatten_padding_selected_experts], axis=0)
     if roll_to_expert_id is not None:
       flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
     sorted_selected_experts = jnp.argsort(flatten_selected_experts)
     # sort inputs for number of selected experts
     replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
+    replicated_inputs_2d = jnp.pad(
+      replicated_inputs_2d,
+      pad_width=(
+          # padding before, padding after
+          (0, flatten_padding_selected_experts.size),
+          (0, 0),
+      ),
+      mode='constant',
+      constant_values=0.0)
     sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
         self.dtype
     )
@@ -797,6 +829,12 @@ class RoutedMoE(nnx.Module):
         use_custom_sort_vjp,
     )
     reshaped_weights = jnp.reshape(weights, (-1, self.num_experts_per_tok))
+    # Strip alignment padding tokens that were appended in _mt_permute.
+    # After unsorting, the first (batch*seq*top_k) rows hold the real token
+    # outputs; any trailing rows are padding tokens (zeroed out) and must be
+    # discarded before the reshape to (batch*seq, top_k, hidden).
+    num_real_tokens = reshaped_weights.shape[0] * self.num_experts_per_tok
+    unsort_intermediate = unsort_intermediate[:num_real_tokens]
     reshaped_intermediate = jnp.reshape(
         unsort_intermediate,
         (reshaped_weights.shape[0], self.num_experts_per_tok, -1),
@@ -1293,7 +1331,7 @@ class RoutedMoE(nnx.Module):
             assert self.config.quantization and self.config.quantization.startswith("te_"), "TE GMM currently requires TE quantization."
             # TODO(jberchtold): Adjust this based on TE GMM requirements per recipe
             TE_GMM_ALIGN_REQUIREMENT = 128
-            assert self.config.te_router_and_permutation_impl and self.config.te_permutation_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
+            assert self.config.te_permutation_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
             return self.quant.gmm(inputs, kernel, tiling, group_sizes, expert_assignments)
 
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
@@ -1581,18 +1619,18 @@ class RoutedMoE(nnx.Module):
             max_local_experts_per_tok = min(local_expert_size, self.config.num_experts_per_tok)
             buffer_size = int(num_expert_parallelism * batch_size * sequence_length * max_local_experts_per_tok)
 
-            # When using TE permutation with padding, the actual data size includes padding overhead.
+            # When using alignment-based padding, the actual data size includes padding overhead.
             # Each expert's tokens are aligned to te_permutation_align_size, which increases the
             # total token count. We need to ensure the buffer can hold the padded data.
-            # Note: Padding is applied in global permute, so this follows global mode
-            if use_te_perm:
-              align_size = self.config.te_permutation_align_size
-              if align_size > 0:
-                # Add headroom for padding: each (shard, expert) chunk can add up to align_size-1 tokens
-                # Worst case: every chunk has 1 token, padded to align_size
-                # Total padding overhead = num_expert_parallelism * local_expert_size * (align_size - 1)
-                padding_headroom = int(num_expert_parallelism * local_expert_size * (align_size - 1))
-                buffer_size = buffer_size + padding_headroom
+            # Note: Padding is applied in global permute, so this follows global mode.
+            # Applied for both TE and MT permutation to support future per-group padding in mt_permute.
+            align_size = self.config.te_permutation_align_size
+            if align_size > 0:
+              # Add headroom for padding: each (shard, expert) chunk can add up to align_size-1 tokens
+              # Worst case: every chunk has 1 token, padded to align_size
+              # Total padding overhead = num_expert_parallelism * local_expert_size * (align_size - 1)
+              padding_headroom = int(num_expert_parallelism * local_expert_size * (align_size - 1))
+              buffer_size = buffer_size + padding_headroom
 
             output_shape = jnp.zeros((buffer_size, self.config.emb_dim), dtype=x.dtype)
 
@@ -1755,17 +1793,17 @@ class RoutedMoE(nnx.Module):
         if num_expert_parallelism > 1:
           original_inputs_first_dim = batch_size * sequence_length * self.config.num_experts_per_tok
 
-          # When using TE permutation with padding, the reverse ragged_all_to_all receives
+          # When using alignment-based padding, the reverse ragged_all_to_all receives
           # padded tokens back. We need a buffer large enough to hold the padded data.
-          # Note: Padding is applied in global permute, so this follows global mode
+          # Note: Padding is applied in global permute, so this follows global mode.
+          # Applied for both TE and MT permutation to support future per-group padding in mt_permute.
           reverse_buffer_size = original_inputs_first_dim
-          if use_te_perm:
-            align_size = self.config.te_permutation_align_size
-            if align_size > 0:
-              # Add headroom for padding: same calculation as forward path
-              # Each expert's tokens can have up to align_size-1 padding overhead
-              padding_headroom = int(self.num_experts * (align_size - 1))
-              reverse_buffer_size = original_inputs_first_dim + padding_headroom
+          align_size = self.config.te_permutation_align_size
+          if align_size > 0:
+            # Add headroom for padding: same calculation as forward path
+            # Each expert's tokens can have up to align_size-1 padding overhead
+            padding_headroom = int(self.num_experts * (align_size - 1))
+            reverse_buffer_size = original_inputs_first_dim + padding_headroom
 
           output_shape = jnp.zeros(
               (

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -699,28 +699,28 @@ class RoutedMoE(nnx.Module):
 
     weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
 
-    token_count_per_expert = jnp.bincount(selected_experts.ravel(), length=self.num_experts)
+    tokens_per_expert = jnp.bincount(selected_experts.ravel(), length=self.num_experts)
     align_size = self.config.moe_permutation_group_align_size
     if align_size > 0:
-      # Use (align - count % align) % align so that experts already aligned to
+      # Use (align - tokens_per_expert % align) % align so that experts already aligned to
       # align_size need 0 padding tokens (not align_size, which would exceed the
       # per-expert slot capacity of align_size - 1).
-      padding_tokens_required_per_expert = (align_size - (token_count_per_expert % align_size)) % align_size
+      padding_tokens_per_expert = (align_size - (tokens_per_expert % align_size)) % align_size
       # Build a static-size padding index buffer.
       # Each expert i gets a slot of (align_size - 1) positions (worst-case padding,
-      # which occurs when token_count[i] % align_size == 1).
-      # Within slot i: positions where offset < padding_tokens_required_per_expert[i]
+      # which occurs when tokens_per_expert[i] % align_size == 1).
+      # Within slot i: positions where offset < padding_tokens_per_expert[i]
       # are assigned to expert i (real padding); the rest point to the last expert
       # as overflow placeholders to keep the buffer statically sized.
-      # E.g. padding_tokens_required_per_expert=(1,3), align_size=8 → total=14:
+      # E.g. padding_tokens_per_expert=(1,3), align_size=8 → total=14:
       #   [0, last, last, last, last, last, last,   # slot 0: 1 real, 6 overflow
       #    1, 1, 1, last, last, last, last]          # slot 1: 3 real, 4 overflow
       max_padding_per_expert = align_size - 1
-      total_padding_size = self.num_experts * max_padding_per_expert
-      positions = jnp.arange(total_padding_size)
+      max_total_padding_size = self.num_experts * max_padding_per_expert
+      positions = jnp.arange(max_total_padding_size)
       expert_for_pos = positions // max_padding_per_expert
       offset_in_slot = positions % max_padding_per_expert
-      padding_needed = padding_tokens_required_per_expert[expert_for_pos]
+      padding_needed = padding_tokens_per_expert[expert_for_pos]
       flatten_padding_selected_experts = jnp.where(
           offset_in_slot < padding_needed,
           expert_for_pos,
@@ -766,15 +766,15 @@ class RoutedMoE(nnx.Module):
         self.dtype
     )
     if align_size > 0:
-      # Compute group_size directly from token_count + required padding rather than
+      # Compute group_size directly from tokens_per_expert + required padding rather than
       # via bincount(flatten_selected_experts).  bincount would include overflow
       # tokens (the static-buffer fill tokens pointing to num_experts-1) in
       # group_size[num_experts-1], making it NOT a multiple of align_size.
       # Direct computation gives each expert exactly ceil(count/align)*align tokens,
       # all guaranteed to be multiples of align_size.
-      group_size = token_count_per_expert + padding_tokens_required_per_expert
+      group_size = tokens_per_expert + padding_tokens_per_expert
     else:
-      group_size = token_count_per_expert
+      group_size = tokens_per_expert
     if roll_to_expert_id is not None:
       # Rolling shifts expert IDs; roll the group_sizes to match.
       group_size = jnp.roll(group_size, -roll_to_expert_id)

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -700,31 +700,32 @@ class RoutedMoE(nnx.Module):
     weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
 
     token_count_per_expert = jnp.bincount(selected_experts.ravel(), length=self.num_experts)
-    align_size = self.config.te_permutation_align_size
-    # Use (align - count % align) % align so that experts already aligned to
-    # align_size need 0 padding tokens (not align_size, which would exceed the
-    # per-expert slot capacity of align_size - 1).
-    padding_tokens_required_per_expert = (align_size - (token_count_per_expert % align_size)) % align_size
-    # Build a static-size padding index buffer.
-    # Each expert i gets a slot of (align_size - 1) positions (worst-case padding,
-    # which occurs when token_count[i] % align_size == 1).
-    # Within slot i: positions where offset < padding_tokens_required_per_expert[i]
-    # are assigned to expert i (real padding); the rest point to the last expert
-    # as overflow placeholders to keep the buffer statically sized.
-    # E.g. padding_tokens_required_per_expert=(1,3), align_size=8 → total=14:
-    #   [0, last, last, last, last, last, last,   # slot 0: 1 real, 6 overflow
-    #    1, 1, 1, last, last, last, last]          # slot 1: 3 real, 4 overflow
-    max_padding_per_expert = align_size - 1
-    total_padding_size = self.num_experts * max_padding_per_expert
-    positions = jnp.arange(total_padding_size)
-    expert_for_pos = positions // max_padding_per_expert
-    offset_in_slot = positions % max_padding_per_expert
-    padding_needed = padding_tokens_required_per_expert[expert_for_pos]
-    flatten_padding_selected_experts = jnp.where(
-        offset_in_slot < padding_needed,
-        expert_for_pos,
-        self.num_experts - 1,
-    )
+    align_size = self.config.moe_permutation_group_align_size
+    if align_size > 0:
+      # Use (align - count % align) % align so that experts already aligned to
+      # align_size need 0 padding tokens (not align_size, which would exceed the
+      # per-expert slot capacity of align_size - 1).
+      padding_tokens_required_per_expert = (align_size - (token_count_per_expert % align_size)) % align_size
+      # Build a static-size padding index buffer.
+      # Each expert i gets a slot of (align_size - 1) positions (worst-case padding,
+      # which occurs when token_count[i] % align_size == 1).
+      # Within slot i: positions where offset < padding_tokens_required_per_expert[i]
+      # are assigned to expert i (real padding); the rest point to the last expert
+      # as overflow placeholders to keep the buffer statically sized.
+      # E.g. padding_tokens_required_per_expert=(1,3), align_size=8 → total=14:
+      #   [0, last, last, last, last, last, last,   # slot 0: 1 real, 6 overflow
+      #    1, 1, 1, last, last, last, last]          # slot 1: 3 real, 4 overflow
+      max_padding_per_expert = align_size - 1
+      total_padding_size = self.num_experts * max_padding_per_expert
+      positions = jnp.arange(total_padding_size)
+      expert_for_pos = positions // max_padding_per_expert
+      offset_in_slot = positions % max_padding_per_expert
+      padding_needed = padding_tokens_required_per_expert[expert_for_pos]
+      flatten_padding_selected_experts = jnp.where(
+          offset_in_slot < padding_needed,
+          expert_for_pos,
+          self.num_experts - 1,
+      )
 
     lb_loss = None
     if self.config.load_balance_loss_weight > 0.0:
@@ -744,31 +745,36 @@ class RoutedMoE(nnx.Module):
       inputs_2d = inputs_2d * router_scores.reshape(bsz_times_seq_len, -1)
 
     flatten_selected_experts = jnp.ravel(selected_experts)
-    flatten_selected_experts = jnp.concatenate([flatten_selected_experts, flatten_padding_selected_experts], axis=0)
+    if align_size > 0:
+      flatten_selected_experts = jnp.concatenate([flatten_selected_experts, flatten_padding_selected_experts], axis=0)
     if roll_to_expert_id is not None:
       flatten_selected_experts = (flatten_selected_experts - roll_to_expert_id) % self.num_experts
     sorted_selected_experts = jnp.argsort(flatten_selected_experts)
     # sort inputs for number of selected experts
     replicated_inputs_2d = jnp.repeat(inputs_2d, self.num_experts_per_tok, axis=0)
-    replicated_inputs_2d = jnp.pad(
-      replicated_inputs_2d,
-      pad_width=(
-          # padding before, padding after
-          (0, flatten_padding_selected_experts.size),
-          (0, 0),
-      ),
-      mode='constant',
-      constant_values=0.0)
+    if align_size > 0:
+      replicated_inputs_2d = jnp.pad(
+        replicated_inputs_2d,
+        pad_width=(
+            # padding before, padding after
+            (0, flatten_padding_selected_experts.size),
+            (0, 0),
+        ),
+        mode='constant',
+        constant_values=0.0)
     sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
         self.dtype
     )
-    # Compute group_size directly from token_count + required padding rather than
-    # via bincount(flatten_selected_experts).  bincount would include overflow
-    # tokens (the static-buffer fill tokens pointing to num_experts-1) in
-    # group_size[num_experts-1], making it NOT a multiple of align_size.
-    # Direct computation gives each expert exactly ceil(count/align)*align tokens,
-    # all guaranteed to be multiples of align_size.
-    group_size = token_count_per_expert + padding_tokens_required_per_expert
+    if align_size > 0:
+      # Compute group_size directly from token_count + required padding rather than
+      # via bincount(flatten_selected_experts).  bincount would include overflow
+      # tokens (the static-buffer fill tokens pointing to num_experts-1) in
+      # group_size[num_experts-1], making it NOT a multiple of align_size.
+      # Direct computation gives each expert exactly ceil(count/align)*align tokens,
+      # all guaranteed to be multiples of align_size.
+      group_size = token_count_per_expert + padding_tokens_required_per_expert
+    else:
+      group_size = token_count_per_expert
     if roll_to_expert_id is not None:
       # Rolling shifts expert IDs; roll the group_sizes to match.
       group_size = jnp.roll(group_size, -roll_to_expert_id)
@@ -804,7 +810,7 @@ class RoutedMoE(nnx.Module):
         load_balance_loss_weight=self.config.load_balance_loss_weight,
         should_update_load_balance=self.should_update_load_balance(),
         routed_bias_update_rate=self.config.routed_bias_update_rate,
-        te_permutation_align_size=self.config.te_permutation_align_size,
+        moe_permutation_group_align_size=self.config.moe_permutation_group_align_size,
         roll_to_expert_id=roll_to_expert_id,
     )
 
@@ -841,12 +847,13 @@ class RoutedMoE(nnx.Module):
         use_custom_sort_vjp,
     )
     reshaped_weights = jnp.reshape(weights, (-1, self.num_experts_per_tok))
-    # Strip alignment padding tokens that were appended in _mt_permute.
-    # After unsorting, the first (batch*seq*top_k) rows hold the real token
-    # outputs; any trailing rows are padding tokens (zeroed out) and must be
-    # discarded before the reshape to (batch*seq, top_k, hidden).
-    num_real_tokens = reshaped_weights.shape[0] * self.num_experts_per_tok
-    unsort_intermediate = unsort_intermediate[:num_real_tokens]
+    if self.config.moe_permutation_group_align_size > 0:
+      # Strip alignment padding tokens that were appended in _mt_permute.
+      # After unsorting, the first (batch*seq*top_k) rows hold the real token
+      # outputs; any trailing rows are padding tokens (zeroed out) and must be
+      # discarded before the reshape to (batch*seq, top_k, hidden).
+      num_real_tokens = reshaped_weights.shape[0] * self.num_experts_per_tok
+      unsort_intermediate = unsort_intermediate[:num_real_tokens]
     reshaped_intermediate = jnp.reshape(
         unsort_intermediate,
         (reshaped_weights.shape[0], self.num_experts_per_tok, -1),
@@ -918,7 +925,7 @@ class RoutedMoE(nnx.Module):
     """
     if perm_state.use_te:
       # When using TE with padding, mask out garbage beyond actual tokens
-      if self.config.te_permutation_align_size > 0:
+      if self.config.moe_permutation_group_align_size > 0:
         actual_tokens = jnp.sum(group_sizes)
         mask = jnp.arange(intermediate_output.shape[0]) < actual_tokens
         intermediate_output = jnp.where(mask[:, None], intermediate_output, 0)
@@ -1343,7 +1350,7 @@ class RoutedMoE(nnx.Module):
             assert self.config.quantization and self.config.quantization.startswith("te_"), "TE GMM currently requires TE quantization."
             # TODO(jberchtold): Adjust this based on TE GMM requirements per recipe
             TE_GMM_ALIGN_REQUIREMENT = 128
-            assert self.config.te_permutation_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.te_permutation_align_size > 0, f"TE GMM currently requires TE permutation with alignment (te_permutation_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
+            assert self.config.moe_permutation_group_align_size % TE_GMM_ALIGN_REQUIREMENT == 0 and self.config.moe_permutation_group_align_size > 0, f"TE GMM currently requires TE permutation with alignment (moe_permutation_group_align_size > 0 and multiple of {TE_GMM_ALIGN_REQUIREMENT})."
             return self.quant.gmm(inputs, kernel, tiling, group_sizes, expert_assignments)
 
       # TODO (b/491979205) pipeline fsdp ag per repeat fails tokamax gmm
@@ -1632,11 +1639,11 @@ class RoutedMoE(nnx.Module):
             buffer_size = int(num_expert_parallelism * batch_size * sequence_length * max_local_experts_per_tok)
 
             # When using alignment-based padding, the actual data size includes padding overhead.
-            # Each expert's tokens are aligned to te_permutation_align_size, which increases the
+            # Each expert's tokens are aligned to moe_permutation_group_align_size, which increases the
             # total token count. We need to ensure the buffer can hold the padded data.
             # Note: Padding is applied in global permute, so this follows global mode.
             # Applied for both TE and MT permutation to support future per-group padding in mt_permute.
-            align_size = self.config.te_permutation_align_size
+            align_size = self.config.moe_permutation_group_align_size
             if align_size > 0:
               # Add headroom for padding: each (shard, expert) chunk can add up to align_size-1 tokens
               # Worst case: every chunk has 1 token, padded to align_size
@@ -1810,7 +1817,7 @@ class RoutedMoE(nnx.Module):
           # Note: Padding is applied in global permute, so this follows global mode.
           # Applied for both TE and MT permutation to support future per-group padding in mt_permute.
           reverse_buffer_size = original_inputs_first_dim
-          align_size = self.config.te_permutation_align_size
+          align_size = self.config.moe_permutation_group_align_size
           if align_size > 0:
             # Add headroom for padding: same calculation as forward path
             # Each expert's tokens can have up to align_size-1 padding overhead

--- a/src/maxtext/layers/moe.py
+++ b/src/maxtext/layers/moe.py
@@ -700,16 +700,21 @@ class RoutedMoE(nnx.Module):
     weights, selected_experts = self.get_topk(gate_logits, pre_bias_logits, rngs)
 
     token_count_per_expert = jnp.bincount(selected_experts.ravel(), length=self.num_experts)
-    padding_tokens_required_per_expert = self.config.te_permutation_align_size - (token_count_per_expert % self.config.te_permutation_align_size)
+    align_size = self.config.te_permutation_align_size
+    # Use (align - count % align) % align so that experts already aligned to
+    # align_size need 0 padding tokens (not align_size, which would exceed the
+    # per-expert slot capacity of align_size - 1).
+    padding_tokens_required_per_expert = (align_size - (token_count_per_expert % align_size)) % align_size
     # Build a static-size padding index buffer.
-    # Each expert i gets a slot of (align_size - 1) positions (worst-case padding).
+    # Each expert i gets a slot of (align_size - 1) positions (worst-case padding,
+    # which occurs when token_count[i] % align_size == 1).
     # Within slot i: positions where offset < padding_tokens_required_per_expert[i]
-    # are assigned to expert i; the rest point to the last expert and will be ignored
-    # by the GEMM (they sort to the tail of the buffer).
+    # are assigned to expert i (real padding); the rest point to the last expert
+    # as overflow placeholders to keep the buffer statically sized.
     # E.g. padding_tokens_required_per_expert=(1,3), align_size=8 → total=14:
     #   [0, last, last, last, last, last, last,   # slot 0: 1 real, 6 overflow
     #    1, 1, 1, last, last, last, last]          # slot 1: 3 real, 4 overflow
-    max_padding_per_expert = self.config.te_permutation_align_size - 1
+    max_padding_per_expert = align_size - 1
     total_padding_size = self.num_experts * max_padding_per_expert
     positions = jnp.arange(total_padding_size)
     expert_for_pos = positions // max_padding_per_expert
@@ -757,14 +762,21 @@ class RoutedMoE(nnx.Module):
     sorted_inputs = _sort_activations(replicated_inputs_2d, sorted_selected_experts, use_custom_sort_vjp).astype(
         self.dtype
     )
-    group_size = jnp.bincount(flatten_selected_experts, length=self.num_experts)
-    # Return the experts for each sorted input.
-    expert_indices = jnp.arange(self.num_experts)
-    sorted_experts = jnp.repeat(
-        expert_indices,
-        repeats=group_size,
-        total_repeat_length=flatten_selected_experts.shape[0],
-    )
+    # Compute group_size directly from token_count + required padding rather than
+    # via bincount(flatten_selected_experts).  bincount would include overflow
+    # tokens (the static-buffer fill tokens pointing to num_experts-1) in
+    # group_size[num_experts-1], making it NOT a multiple of align_size.
+    # Direct computation gives each expert exactly ceil(count/align)*align tokens,
+    # all guaranteed to be multiples of align_size.
+    group_size = token_count_per_expert + padding_tokens_required_per_expert
+    if roll_to_expert_id is not None:
+      # Rolling shifts expert IDs; roll the group_sizes to match.
+      group_size = jnp.roll(group_size, -roll_to_expert_id)
+    # sorted_experts[i] = expert ID of the token at sorted position i.
+    # Directly index flatten_selected_experts (post-roll) by the sort permutation
+    # rather than reconstructing via jnp.repeat, which would need the overflow
+    # count to match total_repeat_length.
+    sorted_experts = flatten_selected_experts[sorted_selected_experts]
     return (
         sorted_inputs,
         sorted_selected_experts,

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -952,6 +952,8 @@ class TransformerEngineQuantization(Quantization):
     """ Grouped GEMM """
     import transformer_engine.jax.flax as te_flax  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
 
+    # Currently only BF16 is supported for TE GMM v2, so we don't use the quantization recipe here yet.
+    # the_recipe = self._recipe
     the_recipe = None
     return te_flax.make_grouped_dense_cls(quantization_recipe=the_recipe)(
         inputs,

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -952,8 +952,6 @@ class TransformerEngineQuantization(Quantization):
     """ Grouped GEMM """
     import transformer_engine.jax.flax as te_flax  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
 
-    # Currently only BF16 is supported for TE GMM v2, so we don't use the quantization recipe here yet.
-    # the_recipe = self._recipe
     the_recipe = None
     return te_flax.make_grouped_dense_cls(quantization_recipe=the_recipe)(
         inputs,

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -949,6 +949,16 @@ class TransformerEngineQuantization(Quantization):
     # quant.einsum is only required for MoE or for inference with KVCache.
     raise ValueError("Einsum is not yet supported for TransformerEngine quantization.")
 
+  def get_gmm_align_size(self, te_gmm_quantization_recipe_name: str):
+    """Get the alignment size for GMM based on the TransformerEngine quantization recipe."""
+    ALIGN_SIZES_BY_RECIPE_NAME = {
+      "te_no_quant": 8, # BF16 alignment requirement for cuBLASLt kernel which is 16B or 8 BF16 elements
+      "te_mxfp8": 128, # MXFP8BlockScaling requirement for TE grouped quant kernel and cuBLASLt MXFP8 grouped GEMM
+    }
+    if te_gmm_quantization_recipe_name not in ALIGN_SIZES_BY_RECIPE_NAME:
+      raise ValueError(f"Invalid TransformerEngine GMM quantization recipe name: {te_gmm_quantization_recipe_name}")
+    return ALIGN_SIZES_BY_RECIPE_NAME[te_gmm_quantization_recipe_name] 
+
   def gmm(self, inputs, kernel, tiling, group_sizes, expert_assignments, te_gmm_quantization_recipe_name):
     """ Grouped GEMM """
     import transformer_engine.jax.flax as te_flax  # pylint: disable=import-outside-toplevel # pytype: disable=import-error

--- a/src/maxtext/layers/quantizations.py
+++ b/src/maxtext/layers/quantizations.py
@@ -851,6 +851,7 @@ class TransformerEngineQuantization(Quantization):
     from transformer_engine.common import recipe  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
 
     RECIPES = {
+        "te_no_quant": lambda: None, 
         "te_fp8_delayedscaling": recipe.DelayedScaling,
         "te_fp8_currentscaling": recipe.Float8CurrentScaling,
         "te_mxfp8": recipe.MXFP8BlockScaling,
@@ -948,14 +949,17 @@ class TransformerEngineQuantization(Quantization):
     # quant.einsum is only required for MoE or for inference with KVCache.
     raise ValueError("Einsum is not yet supported for TransformerEngine quantization.")
 
-  def gmm(self, inputs, kernel, tiling, group_sizes, expert_assignments):
+  def gmm(self, inputs, kernel, tiling, group_sizes, expert_assignments, te_gmm_quantization_recipe_name):
     """ Grouped GEMM """
     import transformer_engine.jax.flax as te_flax  # pylint: disable=import-outside-toplevel # pytype: disable=import-error
 
     # Currently only BF16 is supported for TE GMM v2, so we don't use the quantization recipe here yet.
-    # the_recipe = self._recipe
-    the_recipe = None
-    return te_flax.make_grouped_dense_cls(quantization_recipe=the_recipe)(
+    the_recipe = TransformerEngineQuantization._get_recipe(te_gmm_quantization_recipe_name)
+    # the_recipe = None
+    return te_flax.make_grouped_dense_cls(
+      quantization_recipe=the_recipe,
+      quantization_checkpoint_name="quantization",
+    )(
         inputs,
         kernel,
         group_sizes,

--- a/src/maxtext/layers/te_permutation.py
+++ b/src/maxtext/layers/te_permutation.py
@@ -353,7 +353,7 @@ def te_permute(
     load_balance_loss_weight: float,
     should_update_load_balance: bool,
     routed_bias_update_rate: float,
-    te_permutation_align_size: int,
+    moe_permutation_group_align_size: int,
     roll_to_expert_id: Optional[int] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, Optional[jnp.ndarray],
            Optional[jnp.ndarray], jnp.ndarray, Optional[jnp.ndarray]]:
@@ -377,7 +377,7 @@ def te_permute(
     load_balance_loss_weight: Weight for load balance loss (0 disables).
     should_update_load_balance: Whether to compute bias updates.
     routed_bias_update_rate: Rate for bias updates.
-    te_permutation_align_size: Alignment size for padding (0 disables).
+    moe_permutation_group_align_size: Alignment size for padding (0 disables).
     roll_to_expert_id: Expert ID offset for ring-of-experts.
 
   Returns:
@@ -413,7 +413,7 @@ def te_permute(
   num_tokens = inputs.shape[0] * inputs.shape[1]
   num_out_tokens = num_tokens * num_experts_per_tok
 
-  align_size = te_permutation_align_size
+  align_size = moe_permutation_group_align_size
   if align_size == 0:
     align_size = None
 


### PR DESCRIPTION
# Description

Add support for padding and aligning groups to MaxText's pure-JAX permute codepath. In local testing, this is faster than  the current TE router+permute kernels, mostly due to the TE permute kernels.

This alignment and padding is required for the TE grouped GEMM.